### PR TITLE
fix(launch-critical): confessions clean slate, deploy CLI, EL consent, blog canonicals

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,13 +30,19 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || secrets.SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.SUPABASE_ANON_KEY }}
 
-      - name: 🚀 Deploy to Vercel
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prod'
+      # The previous amondnet/vercel-action@v25 pinned Vercel CLI 25.1.0, which
+      # Vercel's API now rejects ("requires version 47.2.2 or later"), so every
+      # deploy failed at this step. Install the current CLI and deploy directly.
+      # VERCEL_ORG_ID + VERCEL_PROJECT_ID identify the project; the token authes.
+      - name: 🔼 Install latest Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: 🚀 Deploy to Vercel (production)
+        run: vercel deploy --prod --yes --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: 💬 Comment on PR (if applicable)
         if: github.event_name == 'pull_request'

--- a/config/withdrawn-editorial.json
+++ b/config/withdrawn-editorial.json
@@ -1,0 +1,5 @@
+{
+  "_doc": "Consent-withdrawal tombstone for /blog (Empathy Ledger editorial). Add an article slug to `slugs`, or an Empathy Ledger storyteller id to `storytellerIds`, to permanently withhold that content from the site. Enforced by scripts/sync-el-editorial.mjs on every build, including when Empathy Ledger is unreachable and the previous snapshot is kept. This is the positive local signal that honors a withdrawal during an outage, rather than waiting to re-learn it from the source.",
+  "slugs": [],
+  "storytellerIds": []
+}

--- a/docs/strategy/confessions-launch-comms.md
+++ b/docs/strategy/confessions-launch-comms.md
@@ -1,0 +1,137 @@
+# Confessions to Philanthropy — launch comms
+
+Email copy for the Confessions to Philanthropy launch, timed to Queensland
+Philanthropy Week 2026. Send channel: **GoHighLevel Email Builder broadcast to
+the "Newsletter" contact tag** (no automated send exists yet). Check the
+subscriber count in GHL before sending.
+
+Voice rules: no em-dashes, warm and human, a little mischievous, external-facing
+(supporters / funders / the giving sector), never savior-framed. Keep Nic's
+phrasing ("say the thing", the litany). Phone number is the one source of truth:
+`+61 (0) 2 8503 4273`.
+
+Replace `[First name]` with the GHL merge field. Use the live site domain for
+links (production is currently `act-regenerative-studio.vercel.app`).
+
+---
+
+## Issue #1 — Launch (send: Monday, as the week opens)
+
+**Subject (primary):** Hey philanthropy, there is something we have always wanted to say
+**Subject (alt A):** We built a gold phone. Tell it the thing you never say in the room.
+**Subject (alt B):** Confessions to Philanthropy: call the number, say the quiet bit out loud
+**Preheader:** An anonymous voicemail line for the giving sector. Call the gold phone and say the thing.
+
+---
+
+Hi [First name],
+
+This is the first email we have ever sent, so here is the promise up front: short, and only when there is something real to say. There is.
+
+**We built a gold phone.**
+
+It is called Confessions to Philanthropy. An anonymous voicemail line. A public invitation to say the thing.
+
+Over ten years, philanthropy changed the trajectory of Nic's hope and belief about giving. It also opened up a world, a sector and a community he had never heard of. So he and Ben made an artwork that starts a conversation, instead of another report nobody finishes.
+
+It's a gold phone for the things people usually don't say out loud. The things softened by grant language, board papers, thank-you speeches and polite rooms.
+
+You call. You can be anonymous. You say the thing. You leave a message at the tone.
+
+**What do you wish philanthropy knew?**
+
+What have you always wanted to tell it? What have you never confessed?
+
+The good. The weird. The messy. The hopeful. The bullshit. The breakthrough.
+
+Tell us what it gets wrong. Tell us what it gets right. Tell us what no one says in the room. Tell us about the money, the power, the hope, the forms, the love, and the moment it actually changed everything.
+
+No forms. No jargon. No name required.
+
+**One message has already landed.**
+
+> "Hi! I wish there was more money. I wish there was money for everything. In the meantime, keep doing the good work you're doing, and keep sharing the stories, because hopefully that will inspire others."
+
+That is exactly the kind of thing we hoped people would feel safe enough to say. We want yours next.
+
+**Why this week.**
+
+Queensland Gives is opening Queensland Philanthropy Week 2026: more than 24 events to connect, reflect and celebrate giving, led by the connector Tara Castle. The phone is open all week.
+
+It sits in our Art lane, the last word in Listen, Curiosity, Action, Art. Art that makes power feel human again.
+
+**Call the gold phone**
+
+# +61 (0) 2 8503 4273
+
+You can be anonymous. Pick up the phone. Say the thing. Leave a message at the tone.
+
+→ Hear what has been confessed: **/confessions**
+
+Nic and Ben
+A Curious Tractor
+
+*PS. On Friday we play it back. Anonymous, themed, said out loud. Not a survey, not an acquittal. Every number opens back into a voice. Add yours before then.*
+
+---
+
+## Issue #2 — Friday playback (send: Friday, as the week closes)
+
+> Template. Fill the `[ ]` placeholders with real, consented, anonymised
+> messages from the week. Do not invent confessions. A human reads and clears
+> each one first (names and identifying detail removed).
+
+**Subject (primary):** We played it back. Here is what philanthropy heard this week.
+**Subject (alt A):** Philanthropy has [N] new messages
+**Subject (alt B):** The honest version, from Philanthropy Week
+**Preheader:** A week of anonymous voicemails, played back. Themed, unedited, said out loud.
+
+---
+
+Hi [First name],
+
+We left a gold phone open all week and asked the sector to say the thing. [N] of you picked it up.
+
+Here is the honest version. Anonymous, unedited, themed. Not a survey. Not an acquittal. Every number opens back into a voice.
+
+**What came through**
+
+*[The money]*
+> "[real, consented, anonymised excerpt]"
+
+*[The forms]*
+> "[real, consented, anonymised excerpt]"
+
+*[The breakthrough]*
+> "[real, consented, anonymised excerpt]"
+
+[Optional: one or two honest lines about the pattern you heard this week. Stay humble. No savior framing, no tidy bow.]
+
+**The line is still open.**
+
+If you have been holding one, it is not too late.
+
+# +61 (0) 2 8503 4273
+
+Anonymous. Leave a message at the tone.
+
+→ Listen to the full inbox: **/confessions**
+
+Thank you for saying the thing.
+
+Nic and Ben
+A Curious Tractor
+
+*PS. We are not turning your voice into a word cloud. A human reads every message. We will keep listening.*
+
+---
+
+## Send checklist (both issues)
+
+- [ ] Confirm the Dialpad line answers and records on +61 (0) 2 8503 4273 (a dead line on launch day is the worst outcome)
+- [ ] Confirm consent to display any real voicemail quoted here, publicly
+- [ ] Check the "Newsletter" tag subscriber count in GHL
+- [ ] Compose in GHL Email Builder, paste body, set the merge field for [First name]
+- [ ] Set links to the live production domain (not a vercel.app preview)
+- [ ] Send test to self, proof on mobile, then broadcast to the "Newsletter" tag
+- [ ] Align the send with Nic's social post going out the same day

--- a/scripts/check-launch-site.mjs
+++ b/scripts/check-launch-site.mjs
@@ -11,6 +11,7 @@ const repoRoot = process.cwd();
 // routes in src/app/sitemap.ts.
 const launchRoutes = [
   '/',
+  '/confessions',
   '/projects',
   '/stories',
   '/stories/utopia-may-2026',

--- a/scripts/sync-el-editorial.mjs
+++ b/scripts/sync-el-editorial.mjs
@@ -34,6 +34,16 @@ const OUTPUT_PATH = path.resolve(
   'src/data/empathy-ledger-editorial.generated.json'
 );
 
+// Local consent-withdrawal tombstone. Article slugs or storyteller ids listed
+// here are never published, and the rule is enforced even when Empathy Ledger
+// is unreachable and we fall back to the existing snapshot. A withdrawal must
+// be a positive local signal we honor during an outage, not something we can
+// only learn by reaching the source.
+const WITHDRAWN_PATH = path.resolve(
+  process.cwd(),
+  'config/withdrawn-editorial.json'
+);
+
 const PROJECT_EDITORIAL_RECIPES_PATH = path.resolve(
   process.cwd(),
   'src/data/project-editorial-recipes.json'
@@ -76,16 +86,85 @@ async function writeSnapshot(snapshot) {
   await fs.writeFile(OUTPUT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`);
 }
 
-async function keepExistingSnapshot(reason) {
+async function loadWithdrawnTombstone() {
   try {
-    await fs.access(OUTPUT_PATH);
-    console.log(`${reason}, keeping existing EL editorial snapshot at ${OUTPUT_PATH}`);
-    return;
+    const parsed = JSON.parse(await fs.readFile(WITHDRAWN_PATH, 'utf8'));
+    return {
+      slugs: new Set(Array.isArray(parsed.slugs) ? parsed.slugs : []),
+      storytellerIds: new Set(
+        Array.isArray(parsed.storytellerIds) ? parsed.storytellerIds : []
+      ),
+    };
   } catch {
-    const emptySnapshot = createEmptySnapshot();
-    await writeSnapshot(emptySnapshot);
-    console.log(`${reason}, wrote empty EL editorial snapshot to ${OUTPUT_PATH}`);
+    return { slugs: new Set(), storytellerIds: new Set() };
   }
+}
+
+function isWithdrawn(article, tombstone) {
+  const storytellerId = article.storyteller?.id;
+  return (
+    tombstone.slugs.has(article.slug) ||
+    (storytellerId && tombstone.storytellerIds.has(storytellerId))
+  );
+}
+
+function recomputeProjectArticleCounts(articles) {
+  const counts = {};
+  for (const article of articles) {
+    for (const slug of article.relatedProjectSlugs || []) {
+      counts[slug] = (counts[slug] || 0) + 1;
+    }
+  }
+  return counts;
+}
+
+// Drop any withdrawn articles and keep the derived counts honest. Returns the
+// filtered article list plus how many were removed, for logging.
+function enforceWithdrawals(articles, tombstone) {
+  const kept = [];
+  let removed = 0;
+  for (const article of articles) {
+    if (isWithdrawn(article, tombstone)) {
+      removed += 1;
+      console.log(
+        `[sync:el-editorial] consent withdrawn: removing ${article.slug} (honored regardless of Empathy Ledger reachability)`
+      );
+    } else {
+      kept.push(article);
+    }
+  }
+  return { kept, removed };
+}
+
+async function keepExistingSnapshot(reason, tombstone = { slugs: new Set(), storytellerIds: new Set() }) {
+  let existing;
+  try {
+    existing = JSON.parse(await fs.readFile(OUTPUT_PATH, 'utf8'));
+  } catch {
+    await writeSnapshot(createEmptySnapshot());
+    console.log(`${reason}, wrote empty EL editorial snapshot to ${OUTPUT_PATH}`);
+    return;
+  }
+
+  // Even when Empathy Ledger is unreachable, locally-recorded withdrawals must
+  // still take effect, so a storyteller who withdrew during the outage is never
+  // left published in the kept snapshot.
+  const articles = Array.isArray(existing.articles) ? existing.articles : [];
+  const { kept, removed } = enforceWithdrawals(articles, tombstone);
+  if (removed > 0) {
+    await writeSnapshot({
+      ...existing,
+      articles: kept,
+      articleCount: kept.length,
+      projectArticleCounts: recomputeProjectArticleCounts(kept),
+    });
+    console.log(
+      `${reason}, kept existing EL editorial snapshot and enforced ${removed} consent withdrawal(s)`
+    );
+    return;
+  }
+
+  console.log(`${reason}, keeping existing EL editorial snapshot at ${OUTPUT_PATH}`);
 }
 
 async function loadWikiProjectRecords() {
@@ -327,6 +406,8 @@ function sortByPublishedDateDesc(items) {
 }
 
 async function main() {
+  // Loaded before the try so withdrawals are enforced on the fall-back path too.
+  const withdrawn = await loadWithdrawnTombstone();
   try {
     const [
       wikiRecords,
@@ -407,6 +488,20 @@ async function main() {
               projectEditorialRecipes
             );
 
+            // Consent + credit: a person-voiced piece (one with a storyteller)
+            // must never ship under the generic "ACT Team" byline, which erases
+            // the storyteller. Prefer the storyteller's name; if none resolves,
+            // withhold the article until attribution is set in Empathy Ledger
+            // rather than publish it misattributed.
+            const resolvedAuthor =
+              detail.authorName || detail.storyteller?.displayName || '';
+            if (detail.storyteller && !resolvedAuthor) {
+              console.warn(
+                `[sync:el-editorial] withholding ${article.slug}: person-voiced (has a storyteller) but no author name resolved; set attribution in Empathy Ledger to publish`
+              );
+              return null;
+            }
+
             return {
               id: detail.id || article.id,
               title: detail.title || article.title,
@@ -414,7 +509,7 @@ async function main() {
               subtitle: detail.subtitle || article.subtitle || null,
               excerpt: detail.excerpt || article.excerpt || null,
               content: detail.content || article.content || null,
-              authorName: detail.authorName || 'ACT Team',
+              authorName: resolvedAuthor || 'ACT Team',
               authorBio: detail.authorBio || null,
               articleType: detail.articleType || null,
               primaryProject: detail.primaryProject || null,
@@ -491,7 +586,13 @@ async function main() {
       )
     );
 
-    const articles = sortByPublishedDateDesc(detailedArticles);
+    // Drop articles withheld for missing attribution (null) before sorting, then
+    // enforce consent withdrawals on the fresh build too.
+    const hydrated = detailedArticles.filter(Boolean);
+    const { kept: articles } = enforceWithdrawals(
+      sortByPublishedDateDesc(hydrated),
+      withdrawn
+    );
     const projectArticleCounts = {};
 
     for (const article of articles) {
@@ -528,7 +629,8 @@ async function main() {
     await keepExistingSnapshot(
       `[sync:el-editorial] ${
         error instanceof Error ? error.message : 'Failed to build snapshot'
-      }`
+      }`,
+      withdrawn
     );
   }
 }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -38,6 +38,10 @@ export async function generateMetadata({
     description: post.excerpt || 'ACT blog writing carried with consent through Empathy Ledger.',
     path: `/blog/${post.slug}`,
     type: 'article',
+    // These articles are syndicated from Empathy Ledger, which holds the master
+    // copy. Point the canonical at the source so search engines attribute it
+    // there instead of treating /blog as duplicate content.
+    canonicalUrl: post.canonicalUrl,
     image: post.featuredImageUrl
       ? {
           url: post.featuredImageUrl,

--- a/src/app/confessions/page.tsx
+++ b/src/app/confessions/page.tsx
@@ -5,7 +5,7 @@ import { CallTimer } from '@/components/confessions/CallTimer';
 import { ConfessionField } from '@/components/confessions/ConfessionField';
 import { RotaryDial } from '@/components/confessions/RotaryDial';
 import { VoicemailInbox } from '@/components/confessions/VoicemailInbox';
-import { heroVoices, mockConfessions, IS_MOCK } from '@/data/confessions-mock';
+import { heroVoices, mockConfessions, realConfessions, IS_MOCK } from '@/data/confessions-mock';
 import { pageMetadata, siteUrl } from '@/lib/seo/site';
 
 export const metadata = pageMetadata({
@@ -15,11 +15,12 @@ export const metadata = pageMetadata({
   path: '/confessions',
 });
 
-// Real moderated confessions arrive via the Dialpad pipeline (Phase 2). Until
-// IS_MOCK flips to false in confessions-mock, the inbox shows shaped sample
-// messages; after, it reads the real (initially empty) feed. Gating here means
-// nothing fabricated renders once the line goes live.
-const confessions = IS_MOCK ? mockConfessions : [];
+// The inbox shows realConfessions (consented, human-moderated) when live. Set
+// IS_MOCK true only for local design work, which swaps in the shaped sample set.
+// Gating here means nothing fabricated renders once the line is live. New real
+// messages are curated into realConfessions until the Dialpad pipeline (Phase 2)
+// auto-populates them.
+const confessions = IS_MOCK ? mockConfessions : realConfessions;
 
 const QUESTIONS = [
   'What do you wish philanthropy knew?',
@@ -322,7 +323,11 @@ export default function ConfessionsPage() {
           <p className="mx-auto mt-6 max-w-xl font-[var(--font-body)] text-lg leading-8 text-[#C7B9A4]">
             A grantee. A funder willing to be honest on the record. A historian. Someone who has been
             consulted to exhaustion. Confession booth meets late-night talkback. The phone is open the
-            whole of Philanthropy Week.
+            whole of Queensland Philanthropy Week.
+          </p>
+          <p className="mx-auto mt-6 max-w-xl font-[var(--font-body)] text-[15px] leading-8 text-[#A99B86]">
+            Queensland Gives runs the week: Queensland Philanthropy Week 2026, more than 24 events to
+            connect, reflect and celebrate giving, led by the connector Tara Castle.
           </p>
         </div>
       </section>
@@ -334,7 +339,7 @@ export default function ConfessionsPage() {
             Friday
           </p>
           <p className="mt-7 font-[var(--font-sans)] text-sm uppercase tracking-[0.3em] text-[rgba(224,176,104,0.7)]">
-            ▸ Philanthropy has {confessions.length} new messages
+            ▸ Philanthropy has {confessions.length} new {confessions.length === 1 ? 'message' : 'messages'}
           </p>
           <h2 className="mt-5 font-[var(--font-display)] text-[clamp(1.8rem,4.5vw,2.8rem)] font-semibold leading-tight">
             The honest version drops Friday.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,6 @@ import { getHomeEditorialFeature, getSiteEditorialArticles } from "@/lib/empathy
 import { cleanMediaAlt } from "@/lib/media/alt-text";
 import { pageMetadata } from "@/lib/seo/site";
 import featuredSnapshot from "@/data/empathy-ledger-featured.generated.json";
-import { heroFragments } from "@/data/confessions-mock";
 import { CallCTA } from "@/components/confessions/CallCTA";
 import { RotaryDial } from "@/components/confessions/RotaryDial";
 import { FullscreenVideo } from "@/components/flagship/FullscreenVideo";
@@ -234,8 +233,8 @@ export default async function HomePage() {
 
       {/* ---- 1a. CONFESSIONS TO PHILANTHROPY ---- launch campaign lead.
            Matches the /confessions palette (espresso + candlelight gold) so the
-           two read as one campaign. Sample lines reuse the honest mock
-           (heroFragments); the real moderated feed lands via Phase 2. ---- */}
+           two read as one campaign. The chips below are the campaign litany
+           (real invitation copy), never fabricated confessions. ---- */}
       <section className="full-bleed relative overflow-hidden bg-[#15100A] px-6 py-24 text-[#F3EBDD] md:px-10 md:py-32">
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_36%,#241910_0%,#15100A_62%)]" />
         {/* Rotary-dial engraving: the gold-phone object under a single light. */}
@@ -257,12 +256,12 @@ export default async function HomePage() {
             </p>
 
             <ul className="mt-9 flex flex-wrap items-center justify-center gap-2.5 md:justify-start">
-              {heroFragments.slice(1, 4).map((line) => (
+              {['The good.', 'The weird.', 'The messy.', 'The breakthrough.'].map((line) => (
                 <li
                   key={line}
-                  className="rounded-full border border-[#CFA16B]/25 bg-[#CFA16B]/5 px-4 py-2 font-[var(--font-body)] text-[13px] italic text-[#E0D4B9]"
+                  className="rounded-full border border-[#CFA16B]/25 bg-[#CFA16B]/5 px-4 py-2 font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.18em] text-[rgba(224,176,104,0.85)]"
                 >
-                  &ldquo;{line}&rdquo;
+                  {line}
                 </li>
               ))}
             </ul>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -28,6 +28,7 @@ const staticRoutes: Array<{
   priority: number;
 }> = [
   { path: "/", changeFrequency: "weekly", priority: 1.0 },
+  { path: "/confessions", changeFrequency: "weekly", priority: 0.9 },
   { path: "/projects", changeFrequency: "weekly", priority: 0.9 },
   { path: "/stories", changeFrequency: "weekly", priority: 0.8 },
   // Launch hold (2026-05-27): /storytellers held until >1 consented profile syncs.

--- a/src/data/confessions-mock.ts
+++ b/src/data/confessions-mock.ts
@@ -1,7 +1,12 @@
-// MOCK confessions for testing the /confessions experience before the real
-// Dialpad pipeline is live. Shaped to match the eventual moderated output
-// (Dialpad webhook -> strip caller-ID + PII -> human approval -> this shape)
-// so it is a drop-in swap later. NOTHING here is a real message.
+// Confession data for the /confessions experience.
+//
+// `realConfessions` holds the messages we actually display: each one listened to
+// by a human, stripped of identifying detail, and shared with the caller's
+// consent. Add new cleared messages there. `mockConfessions` is the shaped
+// sample set, shown only when IS_MOCK is true (local design/testing, never in
+// production). Both match the eventual moderated output shape (Dialpad webhook
+// -> strip caller-ID + PII -> human approval -> this shape) so the real pipeline
+// is a drop-in later.
 //
 // Redaction convention: runs of "█" mark where a name or identifying detail
 // was removed by the moderator. The wall renders those runs as redaction bars.
@@ -24,8 +29,9 @@ export interface Confession {
   durationSeconds: number;
 }
 
-/** Flip to false the day real moderated confessions replace this. */
-export const IS_MOCK = true;
+/** True shows the sample set (mockConfessions) for local design work; false
+ *  shows realConfessions, the consented messages. Live = false. */
+export const IS_MOCK = false;
 
 /** Theme display + a warm hue per theme (rgb triple) for the visualisations. */
 export const themeMeta: Record<ConfessionTheme, { label: string; rgb: string }> = {
@@ -147,20 +153,20 @@ export const mockConfessions: Confession[] = [
   },
 ];
 
-/** Short, punchy lines for the hero catch-a-voice field (must read in 1-2 lines). */
-export const heroFragments: string[] = [
-  'You backed us when no one else would.',
-  'We needed the grant, so I said nothing.',
-  'Stop calling it a partnership.',
-  'I cried in the car when it came through.',
-  'We are still here.',
-  'The work is so good.',
-  'Why is it usually fourteen months?',
-  'Do better.',
+/** Real, moderated confessions, the messages the inbox actually shows. Each one
+ *  has been listened to by a human, had identifying detail removed, and is
+ *  shared with the caller's consent. Add new cleared messages here. */
+export const realConfessions: Confession[] = [
+  {
+    id: 'c01',
+    theme: 'money',
+    durationSeconds: 22,
+    text: 'Hi! I wish there was more money, I wish there was money for everything. In the meantime, keep doing the good work that you’re doing, and keep sharing the stories because hopefully that will inspire others.',
+  },
 ];
 
-// What the hero catch-a-voice field surfaces: the brief's prompts and litany
-// (real copy, not mock) mixed with the short fragments above. Lives here (a
+// What the hero catch-a-voice field surfaces: the campaign's own prompts and
+// litany, real invitation copy, never a fabricated confession. Lives here (a
 // plain module) so the server page can pass it into the client field without
 // importing a value across the client boundary.
 export const heroVoices: string[] = [
@@ -176,5 +182,4 @@ export const heroVoices: string[] = [
   'Say the quiet bit out loud.',
   'You can be anonymous.',
   'Leave a message at the tone.',
-  ...heroFragments,
 ];

--- a/src/lib/confessions/share-card.tsx
+++ b/src/lib/confessions/share-card.tsx
@@ -29,8 +29,8 @@ const variants: Record<
   },
   answer: {
     kicker: 'Confessions to Philanthropy',
-    headline: '“We needed the grant, so I said nothing.”',
-    sub: 'Confess anonymously. Then see what we build instead.',
+    headline: '“I wish there was money for everything.”',
+    sub: 'A real message, left at the tone. Add yours.',
   },
   invite: {
     kicker: 'Queensland Philanthropy Week',

--- a/src/lib/seo/site.ts
+++ b/src/lib/seo/site.ts
@@ -24,6 +24,14 @@ interface PageMetadataInput {
   path: string;
   type?: 'website' | 'article';
   noIndex?: boolean;
+  /**
+   * Absolute URL to use as the canonical (and og:url) when the master copy of
+   * this content lives off-site, e.g. a syndicated Empathy Ledger article.
+   * Defaults to `path`, keeping pages self-canonical. Set this for any page
+   * that re-publishes content whose canonical home is elsewhere, so search
+   * engines attribute the original rather than flagging duplicate content.
+   */
+  canonicalUrl?: string;
   image?: {
     url: string;
     alt: string;
@@ -38,6 +46,7 @@ export function pageMetadata({
   path,
   type = 'website',
   noIndex = false,
+  canonicalUrl,
   image,
 }: PageMetadataInput): Metadata {
   const imageMeta = image
@@ -51,18 +60,21 @@ export function pageMetadata({
       ]
     : undefined;
 
+  // Point at the off-site source when one is given, otherwise stay self-canonical.
+  const canonical = canonicalUrl || path;
+
   return {
     title,
     description,
     alternates: {
-      canonical: path,
+      canonical,
     },
     openGraph: {
       type,
       siteName: 'A Curious Tractor',
       title,
       description,
-      url: path,
+      url: canonical,
       images: imageMeta,
     },
     twitter: {


### PR DESCRIPTION
## What this ships
Five launch-critical changes on top of the merged site refresh (#39), readying
the site for the Confessions to Philanthropy launch during Queensland Philanthropy
Week 2026.

**Confessions clean slate (`b8d27be`)**
- Removes every fabricated confession from public surfaces: the homepage band,
  the hero catch-a-voice field, and the share-card OG image.
- Flips `IS_MOCK=false`; adds `realConfessions` (consented, human-moderated) as
  the live array, seeded with the first real voicemail.
- Deletes the ungated `heroFragments` (they leaked fakes past the IS_MOCK gate);
  homepage chips now use the campaign litany.
- Adds Queensland Philanthropy Week 2026 / Queensland Gives / Tara Castle context
  to the "The Week" section.
- Registers `/confessions` in `sitemap.ts` and the launch gate.

**Deploy fix (`b61f909`)** — replaces the abandoned `amondnet/vercel-action@v25`
(pinned Vercel CLI 25.1.0, now rejected by Vercel) with `vercel@latest` deployed
directly.

**EL consent (`c715377`)** — the editorial sync keeps storyteller attribution and
honours consent withdrawals (withdrawn-editorial.json tombstones).

**SEO (`10c95ab`)** — syndicated `/blog` canonicals point at the Empathy Ledger
source to avoid duplicate-content penalties.

**Launch comms (`aaee965`)** — first newsletter + Friday playback email drafts at
`docs/strategy/confessions-launch-comms.md`, for sending via GHL to the
"Newsletter" tag. Docs only, no runtime impact.

## Scope
12 files, +330 / −53. No drift from origin/main.

## Test plan
- `tsc --noEmit`: clean (exit 0)
- `npm run check:launch-ready`: all PASS (routes, metadata, brand, copy,
  redirects, media, form-safety) against a local server on :3001
- Rendered HTML: zero fabricated quotes on any surface; the real message renders;
  `/confessions` returns 200

## Deploy (after merge — this does NOT auto-deploy)
The "Deploy to Vercel" workflow is currently `disabled_manually`.
1. `gh workflow enable deploy.yml`
2. Push to main (or `gh workflow run deploy.yml`) to deploy
3. Watch the first run — the Vercel CLI fix could not be proven locally
4. Confirm `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` exist in the
   `production` environment

## Human gates before promoting the campaign
- Dialpad line answers + records on +61 (0) 2 8503 4273
- Consent to display the first voicemail publicly
- Tara Castle named publicly with her / Nic's OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
