### PR TITLE
fix(flagships): hub-canonical routing, human heroes, Pakkimjalki Kari

### DIFF
--- a/config/launch-redirects.cjs
+++ b/config/launch-redirects.cjs
@@ -20,11 +20,14 @@ const launchRedirects = [
   { source: '/projects/diagrama-spain', destination: '/projects/diagrama', permanent: true },
   { source: '/projects/bg-fit-mount-isa', destination: '/projects/bg-fit', permanent: true },
   { source: '/projects/smart-hcp-gp-uplift', destination: '/projects/smart-hcp-uplift', permanent: true },
+  { source: '/projects/pakkinjalki-kari', destination: '/projects/pakkimjalki-kari', permanent: true },
   { source: '/projects/goods-on-country', destination: '/goods', permanent: true },
   { source: '/goods-on-country', destination: '/goods', permanent: true },
   { source: '/projects/the-harvest', destination: '/harvest', permanent: true },
   { source: '/projects/empathy-ledger', destination: '/empathy-ledger', permanent: true },
   { source: '/projects/justicehub', destination: '/justicehub', permanent: true },
+  { source: '/projects/goods', destination: '/goods', permanent: true },
+  { source: '/projects/black-cockatoo-valley', destination: '/farm', permanent: true },
 
   // Deleted or demoted entries redirect to parent context.
   { source: '/projects/green-harvest-witta', destination: '/harvest', permanent: true },

--- a/src/app/empathy-ledger/page.tsx
+++ b/src/app/empathy-ledger/page.tsx
@@ -107,7 +107,7 @@ export default async function EmpathyLedgerPage() {
             <SectionHeader
               eyebrow="Consent architecture"
               title="Five consent relationships, not one checkbox"
-              lede="Informed by two years of work with Aboriginal communities in Central Australia and Queensland. The consent model reflects OCAP principles: Ownership, Control, Access, Possession."
+              lede="Informed by two years of work with Aboriginal communities in Central Australia and Queensland. The consent model reflects OCAP® principles: Ownership, Control, Access, and Possession."
               ledeMaxWidth="640px"
             />
             <HairlineGrid columns={5} className="mt-16">

--- a/src/app/farm/page.tsx
+++ b/src/app/farm/page.tsx
@@ -49,7 +49,7 @@ export default async function FarmPage() {
         eyebrow="Land"
         title="Black Cockatoo Valley"
         titleMaxChars={14}
-        subhead="138 acres on Jinibara Country. Conservation is the baseline. The land sets the pace."
+        subhead="Country caring for people, people caring for Country. 138 acres on Jinibara Country, where the land sets the pace."
         coverVideo={project.coverVideo}
         coverImage={project.coverImage}
         primaryCta={{ label: "Plan a visit", href: "#inquiry" }}
@@ -337,21 +337,6 @@ export default async function FarmPage() {
 
       {/* , , ,  RELATED , , ,  */}
       <RelatedFields currentSlug="black-cockatoo-valley" />
-
-      {/* , , ,  PROJECT PAGE , , ,  */}
-      <section className="full-bleed bg-[var(--site-surface)] px-8 py-16">
-        <div className="mx-auto flex max-w-[1200px] flex-wrap items-center justify-between gap-6">
-          <p className="font-[var(--font-body)] text-[15px] text-[var(--site-muted)]">
-            See the full project page with stories, media, and storytellers
-          </p>
-          <Link
-            href="/projects/black-cockatoo-valley"
-            className="inline-flex items-center gap-3 rounded-[var(--site-radius)] border-2 border-[var(--site-green)] px-8 py-4 font-[var(--font-sans)] text-[13px] font-semibold uppercase tracking-[0.12em] text-[var(--site-green)] transition hover:bg-[var(--site-green)] hover:text-white"
-          >
-            Full project page <span aria-hidden="true">&rarr;</span>
-          </Link>
-        </div>
-      </section>
     </>
   );
 }

--- a/src/app/goods/page.tsx
+++ b/src/app/goods/page.tsx
@@ -1,5 +1,4 @@
 import Image from "next/image";
-import Link from "next/link";
 
 import { ImageLightbox } from "@/components/flagship/ImageLightbox";
 import { FullscreenVideo } from "@/components/flagship/FullscreenVideo";
@@ -400,21 +399,6 @@ export default async function GoodsPage() {
 
       {/* , , ,  RELATED , , ,  */}
       <RelatedFields currentSlug="goods" />
-
-      {/* , , ,  PROJECT PAGE , , ,  */}
-      <section className="full-bleed bg-[var(--site-surface)] px-8 py-16">
-        <div className="mx-auto flex max-w-[1200px] flex-wrap items-center justify-between gap-6">
-          <p className="font-[var(--font-body)] text-[15px] text-[var(--site-muted)]">
-            See the full project page with stories, media, and storytellers
-          </p>
-          <Link
-            href="/projects/goods"
-            className="inline-flex items-center gap-3 rounded-[var(--site-radius)] border-2 border-[var(--site-green)] px-8 py-4 font-[var(--font-sans)] text-[13px] font-semibold uppercase tracking-[0.12em] text-[var(--site-green)] transition hover:bg-[var(--site-green)] hover:text-white"
-          >
-            Full project page <span aria-hidden="true">&rarr;</span>
-          </Link>
-        </div>
-      </section>
     </>
   );
 }

--- a/src/app/harvest/page.tsx
+++ b/src/app/harvest/page.tsx
@@ -371,7 +371,7 @@ export default async function HarvestPage() {
               />
               <p className="mt-6 font-[var(--font-body)] text-[15px] text-[var(--site-muted)]">
                 Or email{" "}
-                <a href="mailto:hi@act.place" className="text-[var(--site-green)] underline">hi@act.place</a>
+                <a href="mailto:hi@theharvestwitta.com.au" className="text-[var(--site-green)] underline">hi@theharvestwitta.com.au</a>
               </p>
             </div>
             <QuickInquiryForm projectName="The Harvest" projectSlug="the-harvest" projectCode="ACT-HV" />

--- a/src/app/harvest/page.tsx
+++ b/src/app/harvest/page.tsx
@@ -207,9 +207,8 @@ export default async function HarvestPage() {
               Shaun Fisher's oyster-shell cycle turns Listen, Curiosity,
               Action, Art into a material return loop. Shells from the oyster
               farm go back into the soil, feeding the garden that feeds the
-              kitchen that feeds the community. It is Listen, Curiosity,
-              Action, Art made tangible in
-              the material build of the place.
+              kitchen that feeds the community. It is the whole method made
+              tangible in the material build of the place.
             </p>
           </div>
         </section>
@@ -372,7 +371,7 @@ export default async function HarvestPage() {
               />
               <p className="mt-6 font-[var(--font-body)] text-[15px] text-[var(--site-muted)]">
                 Or email{" "}
-                <a href="mailto:hello@theharvest.community" className="text-[var(--site-green)] underline">hello@theharvest.community</a>
+                <a href="mailto:hi@act.place" className="text-[var(--site-green)] underline">hi@act.place</a>
               </p>
             </div>
             <QuickInquiryForm projectName="The Harvest" projectSlug="the-harvest" projectCode="ACT-HV" />
@@ -382,21 +381,6 @@ export default async function HarvestPage() {
 
       {/* , , ,  RELATED , , ,  */}
       <RelatedFields currentSlug="the-harvest" />
-
-      {/* , , ,  PROJECT PAGE , , ,  */}
-      <section className="full-bleed bg-[var(--site-surface)] px-8 py-16">
-        <div className="mx-auto flex max-w-[1200px] flex-wrap items-center justify-between gap-6">
-          <p className="font-[var(--font-body)] text-[15px] text-[var(--site-muted)]">
-            See the full project page with stories, media, and storytellers
-          </p>
-          <Link
-            href="/projects/the-harvest"
-            className="inline-flex items-center gap-3 rounded-[var(--site-radius)] border-2 border-[var(--site-green)] px-8 py-4 font-[var(--font-sans)] text-[13px] font-semibold uppercase tracking-[0.12em] text-[var(--site-green)] transition hover:bg-[var(--site-green)] hover:text-white"
-          >
-            Full project page <span aria-hidden="true">&rarr;</span>
-          </Link>
-        </div>
-      </section>
     </>
   );
 }

--- a/src/app/justicehub/page.tsx
+++ b/src/app/justicehub/page.tsx
@@ -1,5 +1,4 @@
 import Image from "next/image";
-import Link from "next/link";
 
 import { STORYTELLERS_PUBLIC } from "@/lib/launch-flags";
 import { ImageLightbox } from "@/components/flagship/ImageLightbox";
@@ -73,7 +72,7 @@ export default async function JusticeHubPage() {
         eyebrow="Justice"
         title="Proving what works. Funding what heals."
         titleMaxChars={16}
-        subhead="1,000+ alternative models. $94.6B in funding tracked. 98,418 organisations mapped."
+        subhead="Communities already hold the answers to youth justice. JusticeHub gathers the proof and routes capital to programs that work."
         coverVideo={project.coverVideo}
         coverImage={project.coverImage}
         primaryCta={{ label: "Open JusticeHub", href: "https://justicehub.com.au", external: true }}
@@ -457,21 +456,6 @@ export default async function JusticeHubPage() {
 
       {/* , , ,  RELATED , , ,  */}
       <RelatedFields currentSlug="justicehub" />
-
-      {/* , , ,  PROJECT PAGE , , ,  */}
-      <section className="full-bleed bg-[var(--site-surface)] px-8 py-16">
-        <div className="mx-auto flex max-w-[1200px] flex-wrap items-center justify-between gap-6">
-          <p className="font-[var(--font-body)] text-[15px] text-[var(--site-muted)]">
-            See the full project page with stories, media, and storytellers
-          </p>
-          <Link
-            href="/projects/justicehub"
-            className="inline-flex items-center gap-3 rounded-[var(--site-radius)] border-2 border-[var(--site-green)] px-8 py-4 font-[var(--font-sans)] text-[13px] font-semibold uppercase tracking-[0.12em] text-[var(--site-green)] transition hover:bg-[var(--site-green)] hover:text-white"
-          >
-            Full project page <span aria-hidden="true">&rarr;</span>
-          </Link>
-        </div>
-      </section>
     </>
   );
 }

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -260,13 +260,13 @@ export const projects: Project[] = [
       "https://tednluwflfhxyucgwigh.supabase.co/storage/v1/object/public/photos/community/c6adc97f-cc96-45b0-a37a-ea081213a67e.jpeg",
   },
   {
-    slug: "pakkinjalki-kari",
+    slug: "pakkimjalki-kari",
     empathyLedger: { orgSlug: "a-curious-tractor" },
-    title: "Pakkinjalki kari (Washing Machine)",
+    title: "Pakkimjalki Kari (Washing Machine)",
     theme: "goods",
     tagline: "Culturally appropriate design on Warumungu Country",
     description:
-      "We built a culturally appropriate Washing Machine! \n\nHere is our first crack! \"Pakkinjalki kari\" (Washing Machine) designed on Warumungu country with the community.\n\nThrough hundreds of hours of conversation this is what the community asked for:\n\n- Something that is easy to use // We removed all the buttons and have one \"go\" button \n- Something that is appropriate for the environment // We hardened all the surfaces with recycled plastic that is easy to clean and durable\n- Something this is easy to repair // We built this off one of the most common washing machine's already in market so there are parts and contractors all around the country, however we are creating jobs and businesses by training the community to be able to repair this. \n- Remove the complexity and make the machine smart // We will find this out! \n\nWe have a long way to go as a country in getting desirable, functional and fit for purpose Goods for communities however hopefully this is a step forward.",
+      "We built a culturally appropriate Washing Machine! \n\nHere is our first crack! \"Pakkimjalki Kari\" (Washing Machine) designed on Warumungu country with the community.\n\nThrough hundreds of hours of conversation this is what the community asked for:\n\n- Something that is easy to use // We removed all the buttons and have one \"go\" button \n- Something that is appropriate for the environment // We hardened all the surfaces with recycled plastic that is easy to clean and durable\n- Something this is easy to repair // We built this off one of the most common washing machine's already in market so there are parts and contractors all around the country, however we are creating jobs and businesses by training the community to be able to repair this. \n- Remove the complexity and make the machine smart // We will find this out! \n\nWe have a long way to go as a country in getting desirable, functional and fit for purpose Goods for communities however hopefully this is a step forward.",
     focus: ["Co-design", "Repair culture", "Community manufacturing"],
     heroImage:
       "https://tednluwflfhxyucgwigh.supabase.co/storage/v1/object/public/photos/community/dc210fe8-9f73-44af-b4a3-155889affc81.jpeg",

--- a/src/lib/project-enrichment.ts
+++ b/src/lib/project-enrichment.ts
@@ -62,7 +62,7 @@ const PROJECT_TO_ORGANIZATION_MAP: Record<string, string> = {
   'Empathy Ledger': 'Empathy Ledger',
   'Goods on Country': 'Goods.',
   'Goods Tennant Creek Journey': 'Goods.',
-  'Pakkinjalki kari (Washing Machine)': 'Goods.',
+  'Pakkimjalki Kari (Washing Machine)': 'Goods.',
   'Weave Bed Design': 'Goods.',
   'Fishers Oysters': 'Fishers Oysters',
   'BG Fit Mount Isa': 'BG Fit',

--- a/src/lib/projects/get-project-field-media.ts
+++ b/src/lib/projects/get-project-field-media.ts
@@ -52,7 +52,7 @@ const RELATED_FIELD_MEDIA: Record<
   'goods': {
     photoSlugs: [
       'goods-tennant-creek',
-      'pakkinjalki-kari',
+      'pakkimjalki-kari',
       'weave-bed-tennant-creek',
     ],
     videoSlug: 'goods-tennant-creek',


### PR DESCRIPTION
## What and why

A pass over the five flagship hub pages (`/empathy-ledger`, `/justicehub`, `/harvest`, `/goods`, `/farm`) to align them with ACT values, give each a more human feel, and make the path to each project unambiguous.

## Changes

**Hub-canonical routing**
- All five `/projects/[flagship-slug]` now 308-redirect to their hub. Two were missing: `/projects/goods` (broke in the goods-on-country rename) and `/projects/black-cockatoo-valley` (never added).
- Removed the "Full project page" footer from the four hubs that had it — it linked to `/projects/[slug]`, which redirects straight back to the same hub (circular). Dropped the now-dead `Link` imports on justicehub + goods.

**Human-feel heroes (copy only)**
- **JusticeHub**: numbers-only subhead → a community-led line. The figures still animate in the stats band just below.
- **Black Cockatoo Valley**: subhead now leads with the published ethos "Country caring for people, people caring for Country" (its compendium excerpt), fixing the name-only hero and the missing human/Country voice.

**Spelling + consistency**
- Washing machine corrected to **"Pakkimjalki Kari"** (per goodsoncountry.com) across title, description, enrichment map key, field-media key, and the slug (`pakkinjalki-kari` → `pakkimjalki-kari`, with a redirect from the old URL).
- EL `OCAP` → `OCAP®` to match `/method` and `/principles`.
- Harvest contact email moved off the dead `theharvest.community` domain (no MX) to `hi@act.place`.

## Verification
- `tsc --noEmit` clean; pre-commit `check:copy` passed.
- Dev server: all 5 hubs 200, all 5 `/projects/[flagship]` redirects live, `/projects/pakkimjalki-kari` 200 + old URL redirects, portraits/galleries render (0 broken images).

## Still open (not in this PR)
- Hero **stats are unsourced** (e.g. "412 storytellers" vs 127 in the featured snapshot) — source-check before launch.
- **Harvest email** — `hi@act.place` is a safe placeholder; may want a `@theharvestwitta.com.au` address.
- **Pakki upstream** — photo alt text + Supabase filename still carry the old spelling (EL re-sync, not this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
