### PR TITLE
feat(confessions): lineage trio + QPW comms calendar

### DIFF
--- a/src/app/confessions/page.tsx
+++ b/src/app/confessions/page.tsx
@@ -36,6 +36,31 @@ const STEPS = [
   { n: '3', label: 'That is it.', sub: 'No form. No grant language. No “dear valued stakeholder”.' },
 ];
 
+// The lineage trio: ACT has a practice of building anonymous truth-telling
+// infrastructure, and Confessions to Philanthropy is the latest in that line.
+// All three slugs resolve at /art/[slug] (verified 200). No em-dashes (ACT voice).
+const LINEAGE = [
+  {
+    year: '2023',
+    title: 'The Confessional',
+    slug: 'the-confessional',
+    line: 'A horse trailer made into a room where honesty becomes possible.',
+  },
+  {
+    year: '2024',
+    title: 'Gold.Phone',
+    slug: 'gold-phone',
+    line: 'A booth that connects strangers by voice. No screens, no profiles.',
+  },
+  {
+    year: '2026',
+    title: 'Confessions to Philanthropy',
+    slug: 'confessions-to-philanthropy',
+    line: 'The same gold phone, pointed at the sector that funds change.',
+    current: true,
+  },
+];
+
 // A short, conservative history. Only well-established beats: the Greek
 // etymology, the waqf as an early perpetual endowment, tzedakah, the langar.
 // No contested figures, no anthropological claims about First Nations culture.
@@ -356,6 +381,58 @@ export default function ConfessionsPage() {
             >
               See the receipts: The Payout Wall <span aria-hidden="true">&rarr;</span>
             </Link>
+          </p>
+        </div>
+      </section>
+
+      {/* THE LINE OF WORK, lineage of the phones we have built */}
+      <section className="border-t border-[#2E2215] bg-[#1A130B] px-6 py-24 md:py-28">
+        <div className="mx-auto max-w-5xl">
+          <div className="text-center">
+            <p className="font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.4em] text-[#CFA16B]">
+              A line of work
+            </p>
+            <h2 className="mx-auto mt-7 max-w-2xl font-[var(--font-display)] text-[clamp(1.7rem,4vw,2.4rem)] font-semibold leading-tight">
+              This is not the first phone we have built.
+            </h2>
+            <p className="mx-auto mt-6 max-w-xl font-[var(--font-body)] text-lg leading-8 text-[#C7B9A4]">
+              For years we have built quiet places where the truth gets easier to say. Confessions to
+              Philanthropy is the latest in that line.
+            </p>
+          </div>
+
+          <ol className="mt-14 grid gap-6 md:grid-cols-3">
+            {LINEAGE.map((w) => (
+              <li key={w.slug}>
+                <Link
+                  href={`/art/${w.slug}`}
+                  className={`group flex h-full flex-col rounded-3xl border p-8 transition ${
+                    w.current
+                      ? 'border-[#CFA16B]/60 bg-[#15100A] shadow-[0_0_36px_-14px_rgba(207,161,107,0.55)]'
+                      : 'border-[#2E2215] bg-[#15100A] hover:border-[#5A4A30]'
+                  }`}
+                >
+                  <span className="font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.3em] text-[#7C7060]">
+                    {w.year}
+                    {w.current && <span className="ml-2 text-[#CFA16B]">the current call</span>}
+                  </span>
+                  <span className="mt-3 font-[var(--font-display)] text-xl font-semibold text-[#E0B068]">
+                    {w.title}
+                  </span>
+                  <span className="mt-3 flex-1 font-[var(--font-body)] text-[15px] leading-7 text-[#C7B9A4]">
+                    {w.line}
+                  </span>
+                  <span className="mt-6 inline-flex items-center gap-1.5 font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.2em] text-[rgba(224,176,104,0.85)] group-hover:text-[#CFA16B]">
+                    See the work <span aria-hidden="true">&rarr;</span>
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ol>
+
+          <p className="mx-auto mt-12 max-w-2xl text-center font-[var(--font-body)] text-[16px] leading-8 text-[#A99B86]">
+            Same idea every time. Take away the screens and the grant language, and people tell the
+            truth. The line is open again, and this time it is pointed at philanthropy.
           </p>
         </div>
       </section>

--- a/thoughts/shared/plans/confessions-qpw-comms-calendar-2026-06-01.md
+++ b/thoughts/shared/plans/confessions-qpw-comms-calendar-2026-06-01.md
@@ -1,0 +1,170 @@
+# Confessions to Philanthropy, Queensland Philanthropy Week comms calendar
+
+**Campaign:** Confessions to Philanthropy (`/confessions`)
+**Window:** Mon 1 June to Fri 5 June 2026 (Queensland Philanthropy Week)
+**Author:** drafted 2026-05-29. Part B of `confessions-lineage-and-cadence-2026-05-28.md`.
+
+## Verified QPW 2026 anchors (two sources)
+- **Mon 1 June, 5:00 to 7:00pm, Queensland Parliament House:** QPW Launch event.
+- **Fri 5 June, 12:00 to 2:30pm, Brisbane City Hall:** Queensland Philanthropy Awards lunch.
+- Run by **Queensland Gives** in partnership with Philanthropy Australia. More than 24 events across the week, connector Tara Castle.
+- Sources: philanthropy.org.au/whats-on/2026-queensland-philanthropy-week, queenslandgives.org.au/philanthropy-week.
+
+**Why the timing works:** our site-refresh deploys the morning of **Mon 1 June** (QPW launch day), so the campaign goes live as the week opens. The Friday playback lands on **Fri 5 June**, the same day the sector is gathered at City Hall for the Awards. The voices have an audience that is literally in the room.
+
+## BEFORE YOU POST (gate, all three required)
+1. **Site is live:** the site-refresh deploy ran and `/confessions`, `/confessions/friday`, `/art/the-payout-wall` all return 200 in production.
+2. **The line answers:** call `+61 (0) 2 8503 4273` and confirm it rings the gold phone and plays the recorded greeting. *This is a human check and cannot be automated. If the line is dead, do not post the number; pivot to lead with the film and the Friday playback until it is live.*
+3. **Cards render:** `/confessions/share/hook`, `/answer`, `/invite` all return a 1200x630 image.
+
+## Channels (priority order for the philanthropy sector)
+1. **LinkedIn** (primary). Sector decision-makers live here.
+2. **Email** (ACT list + sector contacts). Short sequence: announce, mid-week pulse, Friday playback.
+3. **Instagram / X** (secondary amplification, card-led).
+
+## Assets (already produced, nothing new needed)
+- Share cards: `hook`, `answer`, `invite` at `/confessions/share/{variant}` (1200x630, also the OG image on the URL itself).
+- Film + poster: `confessions-to-philanthropy.mp4` / `.jpg`.
+- The number `+61 (0) 2 8503 4273`, the `/confessions` link, the Friday Tape `/confessions/friday`, the data piece `/art/the-payout-wall` (+ method `/art/the-payout-wall/method`).
+- Existing email-builder newsletter copy: `docs/strategy/confessions-launch-comms.md` (use as the Email 1 broadcast; this calendar adds the mid-week and Friday emails).
+
+---
+
+## At a glance
+
+| Day | Date | LinkedIn | Email | IG / X |
+|---|---|---|---|---|
+| 0 | Mon 1 Jun | Announce + film (hook card) | Email 1: announce | Hook card + number |
+| 1 | Tue 2 Jun | Operator's chair: JusticeHub | | answer card |
+| 2 | Wed 3 Jun | Operator's chair: Empathy Ledger | Email 2: mid-week pulse | answer card |
+| 3 | Thu 4 Jun | Operator's chair: Goods on Country | | answer card |
+| 4 | Fri 5 Jun | Friday playback + Payout Wall (invite card) | Email 3: the playback | invite card + Friday Tape clip |
+| evergreen | weekend on | Pass it on, share-kit nudge | | rotate the two unused confession pairings |
+
+Voice on every slot: grounded, warm, a little provocative. No em-dashes. No savior framing. No glossy overclaim. "Not anti-philanthropy. Anti-pretending."
+
+---
+
+## LinkedIn (primary), full copy
+
+### Day 0, Mon 1 June, Announce
+*Attach: the film (autoplay) or the `hook` card. Post mid-morning, before the 5pm launch event.*
+
+> It is Queensland Philanthropy Week. So we built a gold phone and pointed it at the sector.
+>
+> Call it and leave an anonymous voicemail for philanthropy. The thing you usually keep tidy. What you wish it knew. The good, the weird, the bullshit, the breakthrough.
+>
+> No form. No grant language. No "dear valued stakeholder." It rings a gold phone and no one picks up. That is the point.
+>
+> The line is open all week.
+> 📞 +61 (0) 2 8503 4273
+> Listen to what is already coming through: act-regenerative-studio.vercel.app/confessions
+>
+> Not anti-philanthropy. Anti-pretending.
+
+### Day 1, Tue 2 June, Operator's chair: JusticeHub
+*Attach: `answer` card.*
+
+> Day two of the gold phone. A voicemail we keep coming back to:
+>
+> "Programs die the day the grant ends."
+>
+> Everyone in the sector has heard it. Few funders are built to fix it. JusticeHub exists so a program that works does not vanish when a funding round closes. The model is open, forkable, and owned by the communities running it.
+>
+> The line is still open. Tell philanthropy the thing you usually keep tidy.
+> 📞 +61 (0) 2 8503 4273 / act-regenerative-studio.vercel.app/confessions
+
+### Day 2, Wed 3 June, Operator's chair: Empathy Ledger
+*Attach: `answer` card. Email 2 also goes today.*
+
+> Midweek. Another voicemail for philanthropy:
+>
+> "Funders make you perform gratitude for your own story."
+>
+> Storytelling in this sector is too often extractive. The community performs, the funder keeps the footage. Empathy Ledger flips the ownership: consent first, value back to the storyteller, the narrative stays theirs.
+>
+> What would you say if the phone was anonymous? It is.
+> 📞 +61 (0) 2 8503 4273 / act-regenerative-studio.vercel.app/confessions
+
+### Day 3, Thu 4 June, Operator's chair: Goods on Country
+*Attach: `answer` card.*
+
+> Thursday. The gold phone has been busy. One more:
+>
+> "Communities are treated as beneficiaries, never owners."
+>
+> The word beneficiary does a lot of quiet damage. Goods on Country is built the other way round. Remote communities own the enterprise, the design and the upside. Waste becomes product, and the value stays on Country.
+>
+> Tomorrow we play the whole week back. Last chance to leave yours.
+> 📞 +61 (0) 2 8503 4273 / act-regenerative-studio.vercel.app/confessions
+
+### Day 4, Fri 5 June, Friday playback + The Payout Wall
+*Attach: `invite` card, plus a short clip from the Friday Tape. Post in the morning, before the 12pm Awards lunch.*
+
+> Today philanthropy gathers at City Hall for the Queensland Philanthropy Awards. Good. Here is the honest version of the week, played back.
+>
+> All week a gold phone collected anonymous voicemails for the sector. We listened to every one. The threads were money, power and hope. One caller: "Just give the money to the people who actually know what is going on." Another: "Please just ask us. Genuinely ask. When you make the ask human and honest, the answer is always yes."
+>
+> The voices tell you how it feels. The data shows how it is built. We mapped 10,133 Australian foundations and charities. Just 45 of them move half of the $12.95 billion given each year. About 1 in 100 publish an open door. We called it The Payout Wall.
+>
+> Hear the week: act-regenerative-studio.vercel.app/confessions/friday
+> See the receipts: act-regenerative-studio.vercel.app/art/the-payout-wall
+>
+> Not anti-philanthropy. Anti-pretending. The line stays open.
+
+---
+
+## Email sequence
+
+### Email 1, Mon 1 June, Announce
+Use the prepared broadcast in `docs/strategy/confessions-launch-comms.md` (subject options already drafted there). Send to the `newsletter` tag via the GHL email builder. Core: the line is open, the number, the film, the `/confessions` link.
+
+### Email 2, Wed 3 June, Mid-week pulse
+**Subject:** What philanthropy is hearing this week
+**Preview:** Anonymous voicemails, played straight.
+
+> The gold phone has been ringing all week. A few of the messages, word for word:
+>
+> "Programs die the day the grant ends."
+> "Funders make you perform gratitude for your own story."
+> "Just give the money to the people who actually know what is going on."
+>
+> Every day this week, someone sits with what came through and answers out loud. No spin, no acquittal language.
+>
+> The line is open until Friday. If you have been holding something, say it.
+> 📞 +61 (0) 2 8503 4273
+> Listen: act-regenerative-studio.vercel.app/confessions
+>
+> Friday we play the whole week back.
+
+### Email 3, Fri 5 June, The playback
+**Subject:** We played the week back
+**Preview:** The honest version of Philanthropy Week.
+
+> This week we pointed a gold phone at philanthropy and listened to everything that came through. Money, power, hope. Anonymous, themed, said out loud.
+>
+> Then we put the data next to the voices. 10,133 foundations and charities. 45 of them move half of the $12.95 billion. About 1 in 100 publish an open door. We called it The Payout Wall.
+>
+> Hear the week: act-regenerative-studio.vercel.app/confessions/friday
+> See the receipts: act-regenerative-studio.vercel.app/art/the-payout-wall
+>
+> Thank you for listening with us. The line stays open. Pass the number to someone who has been holding a confession.
+
+---
+
+## Instagram / X (secondary, card-led)
+- **Mon:** `hook` card + the number. Caption trimmed from the LinkedIn announce.
+- **Tue to Thu:** `answer` card, one confession line per day (mirror the LinkedIn operator's-chair lines).
+- **Fri:** `invite` card + a 15 to 30s clip from the Friday Tape. Link in bio to `/confessions/friday`.
+- Hashtags, sparingly: #QldPhilanthropyWeek #Philanthropy. Tag Queensland Gives where appropriate.
+
+## Evergreen, pass it on
+- Once per week after launch, a quiet "pass it on" nudge: the `invite` card + "Send the number to someone who has been holding a confession." Link `/confessions`.
+- Two confession pairings are held in reserve for rotation: The Harvest ("Nobody funds the unglamorous infrastructure that actually holds.") and Black Cockatoo Valley ("Impact is a glossy PDF, not a thing that lives in the ground.").
+
+## Guardrails (every slot)
+- No em-dashes. Grounded, warm, a little provocative. Name systems, not people. Public foundations are fair game; never name or shame a private individual.
+- Every link points at a verified-live page (`/confessions`, `/confessions/friday`, `/art/the-payout-wall`).
+- URLs use the canonical live web domain `act-regenerative-studio.vercel.app` (per `src/lib/seo/site.ts`). `act.place` is the email domain only (`hi@act.place`), not a live web address. If a prettier custom domain is live at launch, swap it in everywhere here.
+- The data lines are the locked, verified figures from The Payout Wall (`scripts/build-payout-wall-data.mjs` + `grantscope/output/foundation-power.provenance.md`). Do not round them further or invent new ones.
+- If the phone line is not confirmed answering, pull the number from every slot and lead with the film and the Friday playback until it is live.


### PR DESCRIPTION
## What

**Part A, site** — adds an "A line of work" lineage band to \`/confessions\`, between the Friday-inbox teaser and the closing CTA (provenance right before the final ask). Three cards, oldest to newest, each linking to its \`/art/[slug]\` page (all resolve 200):
- The Confessional (2023)
- Gold.Phone (2024)
- Confessions to Philanthropy (2026, marked "the current call")

Turns the three-way naming collision (Gold.Phone / The Confessional / Confessions read as competing) into one practice of building anonymous truth-telling infrastructure.

**Part B, comms** — `thoughts/shared/plans/confessions-qpw-comms-calendar-2026-06-01.md`: a paste-ready Queensland Philanthropy Week posting calendar (LinkedIn + email + IG), ACT voice.

## QPW 2026 dates (verified, two sources)
- Mon 1 June: launch event, Parliament House
- Fri 5 June: Awards lunch, Brisbane City Hall (Queensland Gives + Philanthropy Australia)

Launch coincides with the site-refresh deploy (Mon 1 June); the Friday playback lands on the Awards-lunch day, when the sector is gathered.

## Verified
- `tsc --noEmit` clean
- `/confessions` renders the band; all three `/art/[slug]` links resolve 200
- single h1 preserved; **zero em-dashes** in rendered copy; `check:copy` passes
- URLs use the canonical live domain (`act-regenerative-studio.vercel.app`), not the dead `act.place` web domain

## Human gate before posting
The gold-phone line (`+61 (0) 2 8503 4273`) answering with its recorded greeting cannot be automated. The calendar gates all posting on confirming the line is live; if dead, it says pivot to the film + Friday playback.

Implements `confessions-lineage-and-cadence-2026-05-28.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)