### PR TITLE
Confessions IA reframe: unify under /confessions + fix the Payout Wall

### DIFF
--- a/config/launch-redirects.cjs
+++ b/config/launch-redirects.cjs
@@ -71,6 +71,13 @@ const launchRedirects = [
   { source: '/projects/three-circles', destination: '/projects', permanent: false },
   { source: '/projects/the-full-idea', destination: '/projects', permanent: false },
   { source: '/projects/annual-field-service', destination: '/projects', permanent: false },
+
+  // Campaign IA unification (2026-05-30): the Payout Wall + its method page moved
+  // under /confessions so the whole Confessions to Philanthropy campaign lives in
+  // one place. 308 permanent so the /art entry, the Friday tape link, and any
+  // shared links keep resolving.
+  { source: '/art/the-payout-wall', destination: '/confessions/wall', permanent: true },
+  { source: '/art/the-payout-wall/method', destination: '/confessions/method', permanent: true },
 ];
 
 module.exports = { launchRedirects };

--- a/scripts/check-launch-site.mjs
+++ b/scripts/check-launch-site.mjs
@@ -12,6 +12,9 @@ const repoRoot = process.cwd();
 const launchRoutes = [
   '/',
   '/confessions',
+  '/confessions/wall',
+  '/confessions/friday',
+  '/confessions/method',
   '/projects',
   '/stories',
   '/stories/utopia-may-2026',

--- a/src/app/confessions/friday/page.tsx
+++ b/src/app/confessions/friday/page.tsx
@@ -30,7 +30,7 @@ export default function FridayTapePage() {
   return (
     <div className="relative min-h-screen bg-[#15100A] text-[#F3EBDD]">
       {/* COLD OPEN */}
-      <section className="full-bleed border-b border-[#2E2215] px-6 pb-14 pt-32 text-center md:pt-40">
+      <section className="full-bleed border-b border-[#2E2215] px-6 pb-14 pt-10 text-center md:pt-14">
         <div className="mx-auto max-w-2xl">
           <p className="font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.4em] text-[#CFA16B]">
             Friday
@@ -80,7 +80,7 @@ export default function FridayTapePage() {
             The voices told us how it feels. The data shows how it is built.
           </p>
           <Link
-            href="/art/the-payout-wall"
+            href="/confessions/wall"
             className="mt-6 inline-flex items-center gap-2 rounded-full border border-[#CFA16B]/40 px-5 py-2.5 text-sm font-semibold text-[#CFA16B] transition hover:border-[#CFA16B] hover:bg-[#CFA16B]/10"
           >
             See the receipts: The Payout Wall <span aria-hidden="true">&rarr;</span>

--- a/src/app/confessions/layout.tsx
+++ b/src/app/confessions/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+import { CampaignNav } from '@/components/confessions/CampaignNav';
+
+// Wraps the whole Confessions to Philanthropy campaign (/confessions and its
+// children: /wall, /friday, /method, /share) with persistent wayfinding. The nav
+// hides itself on the /share card routes (see CampaignNav).
+export default function ConfessionsLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <CampaignNav />
+      {children}
+    </>
+  );
+}

--- a/src/app/confessions/method/page.tsx
+++ b/src/app/confessions/method/page.tsx
@@ -6,7 +6,7 @@ export const metadata = pageMetadata({
   title: 'The Payout Wall — method and right of reply',
   description:
     'How the Payout Wall is built, what the numbers mean, where the limits are, and how a foundation can see and contest its own reading. We hold ourselves to the same standard.',
-  path: '/art/the-payout-wall/method',
+  path: '/confessions/method',
 });
 
 const SECTIONS = [
@@ -39,7 +39,7 @@ const SECTIONS = [
 export default function PayoutWallMethodPage() {
   return (
     <div className="relative min-h-screen bg-[#15100A] text-[#F3EBDD]">
-      <section className="full-bleed border-b border-[#2E2215] px-6 pb-12 pt-32 md:pt-40">
+      <section className="full-bleed border-b border-[#2E2215] px-6 pb-12 pt-10 md:pt-14">
         <div className="mx-auto max-w-2xl text-center">
           <p className="font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.4em] text-[#CFA16B]">
             Method and right of reply
@@ -77,7 +77,7 @@ export default function PayoutWallMethodPage() {
 
           <div className="border-t border-[#2E2215] pt-8 text-center">
             <Link
-              href="/art/the-payout-wall"
+              href="/confessions/wall"
               className="font-[var(--font-sans)] text-xs uppercase tracking-[0.3em] text-[rgba(224,176,104,0.85)] underline-offset-4 hover:underline"
             >
               &larr; Back to the Payout Wall

--- a/src/app/confessions/page.tsx
+++ b/src/app/confessions/page.tsx
@@ -124,7 +124,7 @@ export default function ConfessionsPage() {
         {/* Warm vignette, the object under a single light. */}
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_40%,#0E0A05_100%)]" />
 
-        <div className="relative z-10 mx-auto flex min-h-[100svh] max-w-3xl flex-col items-center justify-center px-6 pb-20 pt-32 text-center">
+        <div className="relative z-10 mx-auto flex min-h-[88svh] max-w-3xl flex-col items-center justify-center px-6 pb-20 pt-10 text-center">
           <CallTimer />
           <h1 className="mt-8 font-[var(--font-display)] text-[clamp(2.6rem,7vw,5rem)] font-semibold leading-[1.02] tracking-tight">
             You’ve reached
@@ -376,7 +376,7 @@ export default function ConfessionsPage() {
           </p>
           <p className="mt-9">
             <Link
-              href="/art/the-payout-wall"
+              href="/confessions/wall"
               className="inline-flex items-center gap-2 rounded-full border border-[#CFA16B]/40 px-5 py-2.5 text-sm font-semibold text-[#CFA16B] transition hover:border-[#CFA16B] hover:bg-[#CFA16B]/10"
             >
               See the receipts: The Payout Wall <span aria-hidden="true">&rarr;</span>

--- a/src/app/confessions/wall/page.tsx
+++ b/src/app/confessions/wall/page.tsx
@@ -12,7 +12,7 @@ const s = wallData.stats;
 export const metadata = pageMetadata({
   title: 'The Payout Wall',
   description: `Australian foundations gave $${s.totalGivingB} billion last year. About ${s.openCount} of them will let you ask. One cell per foundation, the rare open doors lit gold, the voices behind the data on the gold phone.`,
-  path: '/art/the-payout-wall',
+  path: '/confessions/wall',
 });
 
 // Receipts read from the verified snapshot (scripts/build-payout-wall-data.mjs),
@@ -53,7 +53,7 @@ export default function PayoutWallPage() {
   return (
     <div className="relative min-h-screen bg-[#15100A] text-[#F3EBDD]">
       {/* HERO */}
-      <section className="full-bleed border-b border-[#2E2215] px-6 pb-12 pt-32 md:pt-40">
+      <section className="full-bleed border-b border-[#2E2215] px-6 pb-12 pt-10 md:pt-14">
         <div className="mx-auto max-w-3xl text-center">
           <p className="font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.4em] text-[#CFA16B]">
             The receipts
@@ -113,7 +113,7 @@ export default function PayoutWallPage() {
           </p>
           <p className="mt-8">
             <Link
-              href="/art/the-payout-wall/method"
+              href="/confessions/method"
               className="font-[var(--font-sans)] text-xs uppercase tracking-[0.3em] text-[rgba(224,176,104,0.85)] underline-offset-4 hover:underline"
             >
               How we know + right of reply &rarr;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -29,6 +29,9 @@ const staticRoutes: Array<{
 }> = [
   { path: "/", changeFrequency: "weekly", priority: 1.0 },
   { path: "/confessions", changeFrequency: "weekly", priority: 0.9 },
+  { path: "/confessions/wall", changeFrequency: "weekly", priority: 0.8 },
+  { path: "/confessions/friday", changeFrequency: "weekly", priority: 0.8 },
+  { path: "/confessions/method", changeFrequency: "monthly", priority: 0.6 },
   { path: "/projects", changeFrequency: "weekly", priority: 0.9 },
   { path: "/stories", changeFrequency: "weekly", priority: 0.8 },
   // Launch hold (2026-05-27): /storytellers held until >1 consented profile syncs.

--- a/src/components/confessions/CampaignNav.tsx
+++ b/src/components/confessions/CampaignNav.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+// Persistent wayfinding for the Confessions to Philanthropy campaign. Sits at the
+// top of every campaign page (the call, the wall, the tape, the method) so you can
+// move between the areas in one click instead of hunting for an inline link. In
+// flow (not fixed) with top padding that clears the floating global header.
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const ITEMS = [
+  { href: '/confessions', label: 'Confess' },
+  { href: '/confessions/wall', label: 'The Wall' },
+  { href: '/confessions/friday', label: 'Friday Tape' },
+  { href: '/confessions/method', label: 'Method' },
+] as const;
+
+export function CampaignNav() {
+  const path = usePathname();
+  // The share-card routes are clean social previews; no campaign chrome on them.
+  if (path?.startsWith('/confessions/share')) return null;
+  return (
+    <nav
+      aria-label="Confessions to Philanthropy"
+      className="full-bleed relative z-40 flex flex-wrap items-center justify-center gap-x-2 gap-y-2 border-b border-[#2E2215] bg-[#15100A]/95 px-4 pb-3 pt-24 backdrop-blur-sm md:pt-28"
+    >
+      <span className="mr-1 hidden font-[var(--font-sans)] text-[10px] uppercase tracking-[0.22em] text-[#6F6353] md:inline">
+        Confessions to Philanthropy
+      </span>
+      {ITEMS.map((it) => {
+        const active = it.href === '/confessions' ? path === '/confessions' : path.startsWith(it.href);
+        return (
+          <Link
+            key={it.href}
+            href={it.href}
+            aria-current={active ? 'page' : undefined}
+            className={`rounded-full border px-3.5 py-1.5 font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.16em] transition-colors ${
+              active
+                ? 'border-[#CFA16B]/60 bg-[#CFA16B]/15 text-[#EFE6D2]'
+                : 'border-transparent text-[#9A8C73] hover:border-[#3A2C18] hover:text-[#E4D8C4]'
+            }`}
+          >
+            {it.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/confessions/PayoutWall.tsx
+++ b/src/components/confessions/PayoutWall.tsx
@@ -101,9 +101,10 @@ export function PayoutWall() {
         }
         if (open.has(i)) continue; // doors live in the animated layer
         const t = (Math.log10(giving[i] + 1) - minG) / span; // 0..1 by giving
-        // dark brass -> warm gold ramp by giving (less red, more brass)
-        const R = Math.round(74 + 150 * t), G = Math.round(56 + 120 * t), B = Math.round(30 + 74 * t);
-        s.fillStyle = `rgba(${R},${G},${B},${0.32 + 0.5 * t})`;
+        // brass -> warm gold ramp by giving. Floor lifted so every closed door is a
+        // visible mark: the wall reads as a dense field of doors, not empty space.
+        const R = Math.round(96 + 128 * t), G = Math.round(70 + 106 * t), B = Math.round(40 + 64 * t);
+        s.fillStyle = `rgba(${R},${G},${B},${0.5 + 0.42 * t})`;
         s.fillRect(x + pad / 2, y + pad / 2, sz, sz);
       }
     };
@@ -219,10 +220,10 @@ export function PayoutWall() {
   return (
     <div className="w-full">
       <div className="relative w-full overflow-hidden rounded-2xl border border-[#3A2C18] bg-[#0E0A05]">
-        <canvas ref={canvasRef} className="block h-[58vh] min-h-[360px] w-full" aria-hidden="true" />
+        <canvas ref={canvasRef} className="block h-[46vh] min-h-[320px] w-full" aria-hidden="true" />
         {/* legend */}
-        <div className="pointer-events-none absolute left-4 top-4 flex flex-col gap-1 font-[var(--font-sans)] text-[10px] uppercase tracking-[0.18em] text-[#A99B86]">
-          <span className="flex items-center gap-2"><span className="inline-block h-2 w-2 rounded-full bg-[#FFE4AA] shadow-[0_0_8px_2px_rgba(224,176,104,0.8)]" /> {s ? s.openCount : '~112'} with a public door</span>
+        <div className="pointer-events-none absolute left-3 top-3 flex flex-col gap-1.5 rounded-md border border-[#241a10] bg-black/70 px-3.5 py-2.5 font-[var(--font-sans)] text-[10px] uppercase tracking-[0.16em] text-[#C3B5A0] backdrop-blur-[2px]">
+          <span className="flex items-center gap-2"><span className="inline-block h-2 w-2 rounded-full bg-[#FFE4AA] shadow-[0_0_8px_2px_rgba(224,176,104,0.8)]" /> {s ? s.openCount : '~113'} with a public door</span>
           <span className="flex items-center gap-2"><span className="inline-block h-2 w-2 rounded-[1px] bg-[#6b4f2a]" /> {s ? s.nGivers.toLocaleString() : '10,133'} that give, no way in</span>
         </div>
         <div className="pointer-events-none absolute bottom-3 right-4 hidden font-mono text-[10px] tracking-[0.05em] text-[#7C7060] sm:block">


### PR DESCRIPTION
Full IA reframe of the Confessions to Philanthropy campaign (per Ben's "part shit / hard to get around" review).

## What changed
- **Wayfinding:** persistent `CampaignNav` (Confess / The Wall / Friday Tape / Method) on every campaign page via `confessions/layout.tsx`, current page marked; hidden on `/share` card routes.
- **URLs unified under `/confessions`:** Payout Wall `/art/the-payout-wall` → `/confessions/wall`, method → `/confessions/method`. **308 redirects** from both old `/art` URLs.
- **Payout Wall canvas:** legend on a readable plate, dim-field floor lifted so it reads as a dense wall of closed doors (not empty), height tightened.
- Heroes re-padded under the nav; `sitemap.ts` + `check-launch-site.mjs` updated.

## Verified
- `npm run build` exit 0 — all six `/confessions/*` routes static, old `/art` route gone.
- `check:launch` passed — 120 routes, h1s, metadata, CTAs, consent leaks, sitemap.
- `tsc --noEmit` clean; new routes 200, old URLs 308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)