### PR TITLE
feat(forms): stamp newsletter_consent=Yes at signup source

### DIFF
--- a/src/app/api/forms/submit/route.ts
+++ b/src/app/api/forms/submit/route.ts
@@ -210,11 +210,21 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
     const str = (value: unknown): string | undefined =>
       typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 
+    // A newsletter signup is an explicit, express opt-in (email typed into a
+    // clearly-labelled newsletter box). Stamp consent + belonging here, at the
+    // source, so it never depends on a GHL workflow trigger firing on an
+    // API-created contact (those are unreliable). newsletter_consent is the ONLY
+    // legal send signal and is set HERE and nowhere else by inference. Field id =
+    // the GHL custom field contact.newsletter_consent (SINGLE_OPTIONS Yes/No).
+    const isNewsletter = body.formType === 'newsletter';
+    const NEWSLETTER_CONSENT_FIELD_ID = 'aVnqmajnysMtGYhLD0oA';
+
     const tags = Array.from(
       new Set([
         ...body.additionalTags,
         ...(body.projectCode ? [body.projectCode] : []),
         ...(body.formType ? [body.formType] : []),
+        ...(isNewsletter ? ['tier:connected', 'comms:act-newsletter'] : []),
       ])
     );
 
@@ -226,6 +236,9 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
       name: str(fields.name) || str(fields.fullName),
       source: 'act-regenerative-studio',
       tags,
+      ...(isNewsletter
+        ? { customFields: [{ id: NEWSLETTER_CONSENT_FIELD_ID, field_value: 'Yes' }] }
+        : {}),
     });
 
     // Open an opportunity in the mapped pipeline for team tracking. Off by

--- a/src/lib/ghl/client.ts
+++ b/src/lib/ghl/client.ts
@@ -28,7 +28,12 @@ export interface GHLContact {
   country?: string;
   source?: string;
   tags?: string[];
-  customFields?: Record<string, any>;
+  // GHL's /contacts API expects customFields as an ARRAY of {id|key, field_value}.
+  // The legacy Record form is kept for back-compat but the array form is what
+  // actually sets a field (verified against the live API 2026-06-02).
+  customFields?:
+    | Array<{ id?: string; key?: string; field_value: unknown }>
+    | Record<string, any>;
   dateOfBirth?: string;
   companyName?: string;
   website?: string;


### PR DESCRIPTION
## What

Stamp `newsletter_consent=Yes` + belonging tags on newsletter signups **in code, at the upsert**, rather than relying on a GHL workflow trigger (unreliable on API-created contacts).

## Live path (verified)

`ACT_ECOSYSTEM_API_URL` is unset in Vercel production, so `/api/forms/submit` forwards to `localhost:3456` (unreachable from Vercel) → `handleFallback()` → `pushToGHL()`. **`pushToGHL` is the live prod path**; the act-ecosystem Command Center handler is localhost-only and not on the prod path.

## Change (commit 40730cb)

For `formType === 'newsletter'` only, `pushToGHL()`:
- sets `customFields: [{ id: 'aVnqmajnysMtGYhLD0oA', field_value: 'Yes' }]` (the `contact.newsletter_consent` SINGLE_OPTIONS field, sent as the array form GHL actually honors)
- adds tags `tier:connected`, `comms:act-newsletter`
- carries it in the single `/contacts/upsert` call (no array-replacing PUT)

`GHLContact.customFields` type widened to accept the array form.

## Resulting GHL state on a newsletter signup

Contact (location `agzsSZWgovjwgpcoASWG`) with `newsletter_consent = Yes` + tags `tier:connected`, `comms:act-newsletter`, `newsletter`, `act-regenerative-studio`. No opportunity (subscriber, not a pipeline lead). Consent is **never** inferred from "has an email."

## Verification

`tsc --noEmit` → 0 errors. `next build` → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)