### PR TITLE
feat(forms): namespaced journey tags + intake-workflow webhook

### DIFF
--- a/src/app/api/forms/submit/route.ts
+++ b/src/app/api/forms/submit/route.ts
@@ -218,12 +218,28 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
     // the GHL custom field contact.newsletter_consent (SINGLE_OPTIONS Yes/No).
     const isNewsletter = body.formType === 'newsletter';
     const NEWSLETTER_CONSENT_FIELD_ID = 'aVnqmajnysMtGYhLD0oA';
+    const CONSENT_SOURCE_FIELD_ID = 'HdnMUyXkZRPZG7l7cygG';
+
+    // Per-form namespaced tags so each submission seats the contact correctly for the
+    // belonging journey: how they arrived (source:) + what they did (role:/action:).
+    // The tier: RUNG and the DATE fields are deliberately NOT set here — the GHL intake
+    // workflow applies them via native actions (reliable tag-added + set-if-empty),
+    // per decision #7 in act-global-infrastructure/thoughts/shared/plans/2026-06-02-harvest-ghl-tier1-build.md.
+    const FORM_RULES: Record<string, string[]> = {
+      newsletter: ['source:website-form'],
+      contact: ['source:website-form'],
+      donation: ['source:website-form', 'role:supporter', 'action:contributed'],
+      volunteer: ['source:website-form', 'role:volunteer'],
+      event: ['source:event-signup', 'interest:events', 'action:attended'],
+    };
+    const formTags = FORM_RULES[body.formType ?? ''] ?? ['source:website-form'];
 
     const tags = Array.from(
       new Set([
         ...body.additionalTags,
         ...(body.projectCode ? [body.projectCode] : []),
         ...(body.formType ? [body.formType] : []),
+        ...formTags,
         ...(isNewsletter ? ['tier:connected', 'comms:act-newsletter'] : []),
       ])
     );
@@ -237,7 +253,12 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
       source: 'act-regenerative-studio',
       tags,
       ...(isNewsletter
-        ? { customFields: [{ id: NEWSLETTER_CONSENT_FIELD_ID, field_value: 'Yes' }] }
+        ? {
+            customFields: [
+              { id: NEWSLETTER_CONSENT_FIELD_ID, field_value: 'Yes' },
+              { id: CONSENT_SOURCE_FIELD_ID, field_value: 'act-regenerative-studio' },
+            ],
+          }
         : {}),
     });
 

--- a/src/app/api/forms/submit/route.ts
+++ b/src/app/api/forms/submit/route.ts
@@ -262,6 +262,28 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
         : {}),
     });
 
+    // Notify the GHL "ACT — Intake" workflow (Inbound Webhook trigger) so it seats the
+    // contact on the Membership Journey via NATIVE actions (reliable trigger + tag-added),
+    // per decision #7. Fire-and-forget — a webhook hiccup must never fail the signup.
+    const INTAKE_WEBHOOK_URL = process.env.GHL_INTAKE_WEBHOOK_URL
+      || 'https://services.leadconnectorhq.com/hooks/agzsSZWgovjwgpcoASWG/webhook-trigger/8432ee10-f5d5-4f72-a6fb-5f0829b937c6';
+    try {
+      await fetch(INTAKE_WEBHOOK_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: str(fields.email),
+          formType: body.formType || 'general',
+          projectCode: body.projectCode || '',
+          firstName: str(fields.firstName),
+          lastName: str(fields.lastName),
+          name: str(fields.name) || str(fields.fullName),
+        }),
+      });
+    } catch (webhookError) {
+      console.error('GHL intake webhook notify failed (non-fatal):', webhookError);
+    }
+
     // Open an opportunity in the mapped pipeline for team tracking. Off by
     // default; set GHL_ENABLE_PIPELINES=true once the routing is reviewed.
     let opportunity: GHLPushResult['opportunity'] = 'skipped';


### PR DESCRIPTION
Lane C of the Harvest GHL Tier-1 build (thoughts/shared/plans/2026-06-02-harvest-ghl-tier1-build.md).

- Per-form FORM_RULES write namespaced `source:`/`role:`/`action:` tags so each submission seats the contact for the belonging journey; newsletter also writes `consent_source`.
- After the upsert, POST {email,formType,projectCode,name} to the GHL 'ACT — Intake' workflow's Inbound Webhook so it seats the contact at Connected via native actions (reliable trigger + tag-added), per decision #7. Fire-and-forget — a webhook hiccup never fails a signup.
- `tier:` rung + DATE fields are set by the workflow (native), not the upsert.

Only src/app/api/forms/submit/route.ts changes (+44/-1). tsc clean, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)