### PR TITLE
fix(build)+feat(forms): unblock prod deploy (staticPageGenerationTimeout) + projectCode-derived tags

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,12 @@
 const { launchRedirects } = require('./config/launch-redirects.cjs');
 
 const nextConfig = {
+  // Data-heavy routes (/projects/[slug], /ecosystem, /empathy-ledger, /art/*,
+  // /sitemap) fetch EL/Supabase at build-time static generation and were blowing
+  // the default 60s per-page cap, failing the whole production deploy. Raise the
+  // cap so slow-but-finite fetches complete and the build stays fully static.
+  // If a fetch ever truly hangs past this, switch those routes to runtime/ISR.
+  staticPageGenerationTimeout: 180,
   images: {
     remotePatterns: [
       {

--- a/src/app/api/forms/submit/route.ts
+++ b/src/app/api/forms/submit/route.ts
@@ -21,6 +21,24 @@ interface NormalizedFormSubmission {
 
 const SOURCE_SITE_TAG = 'act-regenerative-studio';
 
+// projectCode → CRM identity. The namespaced `project:` tag and the newsletter
+// comms-list slug BOTH derive from a form's projectCode — never hardcoded — so a
+// newsletter embedded on any project's page seats to THAT project's list, not
+// ACT-IN's. This is the "route by projectCode, never by formType" contract.
+// Canonical taxonomy + tag scheme: act-global-infrastructure
+// wiki/decisions/act-site-form-alignment.md (the VERIFIED registry, §4a).
+// Slugs for ACT-BV / ACT-AS are provisional (not yet pinned in registry §4a).
+const PROJECT_REGISTRY: Record<string, { tag: string; commsSlug: string }> = {
+  'ACT-IN': { tag: 'project:act-in', commsSlug: 'act' },                     // ACT ecosystem (act.place default)
+  'ACT-HV': { tag: 'project:act-hv', commsSlug: 'harvest' },                 // The Harvest
+  'ACT-BV': { tag: 'project:act-bv', commsSlug: 'farm' },                    // Black Cockatoo Valley / Farm (provisional)
+  'ACT-AS': { tag: 'project:act-as', commsSlug: 'art' },                     // Art / residency (provisional)
+  'ACT-EL': { tag: 'project:empathy-ledger', commsSlug: 'empathy-ledger' },  // Empathy Ledger (OCAP-gated)
+  'ACT-JH': { tag: 'project:justicehub', commsSlug: 'justicehub' },          // JusticeHub
+  'ACT-GD': { tag: 'project:goods', commsSlug: 'goods' },                    // Goods
+};
+const DEFAULT_PROJECT = PROJECT_REGISTRY['ACT-IN'];
+
 function normalizeTags(tags: unknown): string[] {
   if (!Array.isArray(tags)) return [];
 
@@ -234,13 +252,21 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
     };
     const formTags = FORM_RULES[body.formType ?? ''] ?? ['source:website-form'];
 
+    // Derive the project's CRM identity from projectCode (default ACT-IN). The
+    // namespaced project: tag and the newsletter comms list both come from here —
+    // a newsletter on the Harvest page (ACT-HV) gets comms:harvest-newsletter,
+    // NOT comms:act-newsletter. This closes the "newsletter == Harvest" bug class
+    // by routing on projectCode rather than assuming the ACT-IN list.
+    const project = PROJECT_REGISTRY[body.projectCode ?? ''] ?? DEFAULT_PROJECT;
+
     const tags = Array.from(
       new Set([
         ...body.additionalTags,
         ...(body.projectCode ? [body.projectCode] : []),
+        project.tag,
         ...(body.formType ? [body.formType] : []),
         ...formTags,
-        ...(isNewsletter ? ['tier:connected', 'comms:act-newsletter'] : []),
+        ...(isNewsletter ? ['tier:connected', `comms:${project.commsSlug}-newsletter`] : []),
       ])
     );
 


### PR DESCRIPTION
## What this ships
Two stacked fixes that together unblock and correct the production deploy. Merging this triggers the first green production deploy of `act-regenerative-studio` since PR #49 — to **`act-regenerative-studio.vercel.app`** (the interim main ACT-site URL). **`act.place` is not attached to this project, so it is untouched.**

### 1. `fix(build)` — raise `staticPageGenerationTimeout` to 180s (`5afa707`)
The last two production deploys (PR #50, `a697b5c`) failed. Diagnosed from the Vercel build logs (`dpl_4coV8qNcmbEJmL78RaPjMkB4HARq`): build-time static generation of data-heavy routes — `/projects/[slug]` (per slug), `/ecosystem`, `/empathy-ledger`, `/art/{artists,artworks,commissions}`, `/sitemap` — exceeded the default **60s** per-page cap fetching EL/Supabase, retried 3×, and failed the whole deploy.

Raising the cap to 180s lets the slow-but-finite fetches complete while keeping every page **statically generated** (best SEO/perf, zero per-page change). Fallback if a fetch ever truly hangs past this: move those routes to runtime/ISR.

### 2. `feat(forms)` — derive `project:` tag + comms list from `projectCode` (`1367d14`)
The newsletter path hardcoded `comms:act-newsletter` and emitted no namespaced `project:` tag, so a newsletter embedded on any project's page (e.g. Harvest, `ACT-HV`) was tagged for the ACT-IN ecosystem list regardless of the form's declared `projectCode` — the root of the "newsletter == Harvest" mis-seating. Both the `project:` tag and the comms-list slug now derive from `projectCode` via `PROJECT_REGISTRY` (default ACT-IN). ACT-IN behaviour unchanged; the mis-route is closed by construction.

## Verification
- `tsc --noEmit` clean on the route change.
- `next.config.js` parses; `staticPageGenerationTimeout = 180`.
- **Not deploy-verified** — the 180s bump should fix the timeout if fetches are slow-but-finite (logs suggest so). Confirm via this deploy.
- Mis-seat audit (separate): 0 act.place-newsletter contacts currently mis-seated on Harvest — the seating webhook never deployed, so this is a forward-looking fix.

## Note
The GHL "ACT — Intake" workflow still needs repointing to route by `projectCode` (GHL UI) before the seating webhook's effect is fully correct — tracked in `act-global-infrastructure` (`wiki/decisions/act-site-form-alignment.md`). This PR is safe to deploy regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
