### PR TITLE
fix(forms): align act.place forms to canonical GHL tag contract (P1)

### DIFF
--- a/src/app/api/forms/submit/route.ts
+++ b/src/app/api/forms/submit/route.ts
@@ -257,8 +257,27 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
       newsletter: ['source:website', 'role:supporter'],
       contact: ['source:website'],
       donation: ['source:website', 'role:supporter', 'action:contributed'],
-      volunteer: ['source:website', 'role:volunteer'],
+      // taxonomy wants role:supporter + interest:volunteer (both canonical), not a
+      // bare role:volunteer — flagged as a follow-up in commit a807396. No live
+      // act.place form emits `volunteer` today (native/future path), zero live impact.
+      volunteer: ['source:website', 'role:supporter', 'interest:volunteer'],
+      // TODO(event): taxonomy wants source:event:<slug> (per-event), which needs the
+      // form to pass the event slug. Left as source:event-signup until that plumbing
+      // exists; no live act.place form emits `event` today.
       event: ['source:event-signup', 'interest:events', 'action:attended'],
+      // P1 contract alignment (2026-06-08, plan
+      // act-global-infrastructure/thoughts/shared/plans/2026-06-08-whole-system-forms-tag-alignment.md).
+      // The five inquiry/application forms. These are NOT newsletters: they grant
+      // NO comms:/newsletter_consent (only the newsletter formType does, below) —
+      // identity tags only, so a smart-list can find them but no send fires.
+      // role:supporter is the field-justified role (these forms capture no field
+      // that justifies role:partner/funder); the flagship `interest` select is
+      // preserved in fields for human follow-up, not auto-promoted to a role.
+      csa: ['source:website', 'role:supporter', 'interest:membership'],
+      'farm-stay': ['source:website', 'role:supporter', 'interest:farm-stay'],
+      residency: ['source:website', 'role:supporter', 'interest:residency'],
+      'payout-wall-contest': ['source:website', 'role:supporter', 'interest:justice-reform'],
+      'flagship-inquiry': ['source:website', 'role:supporter'],
     };
     const formTags = FORM_RULES[body.formType ?? ''] ?? ['source:website'];
 
@@ -274,9 +293,21 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
     // (project:act-in) and the per-form rules carry the same meaning without
     // polluting the tag space the smart-lists query. body.additionalTags is the
     // form's own namespaced provenance (e.g. source:website-footer).
+    //
+    // Contract guard (P1, 2026-06-08): only colon-namespaced tags reach GHL.
+    // Defense in depth — drops any flat tag a form (or the SOURCE_SITE_TAG) tries
+    // to send, so a single regression can't repollute the tag space the
+    // smart-lists query. Dropped tags are logged (visible regression signal) and
+    // the FULL raw additionalTags are still preserved on the Supabase fallback row
+    // (handleFallback), so no provenance is lost — it just doesn't become a GHL tag.
+    const namespacedExtra = body.additionalTags.filter((t) => t.includes(':'));
+    const droppedFlat = body.additionalTags.filter((t) => !t.includes(':'));
+    if (droppedFlat.length > 0) {
+      console.warn(`Dropped ${droppedFlat.length} non-namespaced tag(s) before GHL: ${droppedFlat.join(', ')}`);
+    }
     const tags = Array.from(
       new Set([
-        ...body.additionalTags,
+        ...namespacedExtra,
         project.tag,
         ...formTags,
         ...(isNewsletter ? ['tier:curious', `comms:${project.commsSlug}-newsletter`] : []),

--- a/src/app/api/forms/submit/route.ts
+++ b/src/app/api/forms/submit/route.ts
@@ -240,17 +240,27 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
 
     // Per-form namespaced tags so each submission seats the contact correctly for the
     // belonging journey: how they arrived (source:) + what they did (role:/action:).
-    // The tier: RUNG and the DATE fields are deliberately NOT set here — the GHL intake
-    // workflow applies them via native actions (reliable tag-added + set-if-empty),
-    // per decision #7 in act-global-infrastructure/thoughts/shared/plans/2026-06-02-harvest-ghl-tier1-build.md.
+    // A newsletter signup seeds the ENTRY rung tier:curious (see the tags block
+    // below); the DATE fields and rung ADVANCEMENT (curious→connected→member) are
+    // applied by the GHL intake workflow via native actions (reliable tag-added +
+    // set-if-empty), per decision #7 in
+    // act-global-infrastructure/thoughts/shared/plans/2026-06-02-harvest-ghl-tier1-build.md.
+    //
+    // Slug is source:website (channel) per the canonical taxonomy
+    // (act-global-infrastructure wiki/concepts/ghl-audience-comms-automation.md
+    // §"Forms → tag contract"). A newsletter signup is an express opt-in BY a
+    // supporter, so it also seats role:supporter — the identity tag the
+    // "Org supporters" smart-list (role:supporter AND newsletter_consent=Yes AND
+    // NOT lane:community) queries on. Without it, signups are invisible to that
+    // segment and to role-gated automations (e.g. the supporter onboarding drip).
     const FORM_RULES: Record<string, string[]> = {
-      newsletter: ['source:website-form'],
-      contact: ['source:website-form'],
-      donation: ['source:website-form', 'role:supporter', 'action:contributed'],
-      volunteer: ['source:website-form', 'role:volunteer'],
+      newsletter: ['source:website', 'role:supporter'],
+      contact: ['source:website'],
+      donation: ['source:website', 'role:supporter', 'action:contributed'],
+      volunteer: ['source:website', 'role:volunteer'],
       event: ['source:event-signup', 'interest:events', 'action:attended'],
     };
-    const formTags = FORM_RULES[body.formType ?? ''] ?? ['source:website-form'];
+    const formTags = FORM_RULES[body.formType ?? ''] ?? ['source:website'];
 
     // Derive the project's CRM identity from projectCode (default ACT-IN). The
     // namespaced project: tag and the newsletter comms list both come from here —
@@ -259,14 +269,17 @@ async function pushToGHL(body: NormalizedFormSubmission): Promise<GHLPushResult>
     // by routing on projectCode rather than assuming the ACT-IN list.
     const project = PROJECT_REGISTRY[body.projectCode ?? ''] ?? DEFAULT_PROJECT;
 
+    // Namespaced tags ONLY. The raw projectCode ("ACT-IN") and raw formType
+    // ("newsletter") are intentionally NOT seated as flat tags — project.tag
+    // (project:act-in) and the per-form rules carry the same meaning without
+    // polluting the tag space the smart-lists query. body.additionalTags is the
+    // form's own namespaced provenance (e.g. source:website-footer).
     const tags = Array.from(
       new Set([
         ...body.additionalTags,
-        ...(body.projectCode ? [body.projectCode] : []),
         project.tag,
-        ...(body.formType ? [body.formType] : []),
         ...formTags,
-        ...(isNewsletter ? ['tier:connected', `comms:${project.commsSlug}-newsletter`] : []),
+        ...(isNewsletter ? ['tier:curious', `comms:${project.commsSlug}-newsletter`] : []),
       ])
     );
 

--- a/src/components/confessions/FoundationContestForm.tsx
+++ b/src/components/confessions/FoundationContestForm.tsx
@@ -46,13 +46,13 @@ export function FoundationContestForm() {
         body: JSON.stringify({
           projectCode: 'ACT-IN',
           formType: 'payout-wall-contest',
-          fields: form,
-          additionalTags: [
-            'Payout Wall',
-            'Data contest / right of reply',
-            `Foundation: ${form.foundation}`,
-            'Route: /confessions/wall',
-          ],
+          // foundation + the submitter's role are already in `form` (the fields).
+          // Page provenance lives in fields, not tags. Canonical
+          // source:/role:/interest:/project: tags are applied server-side by
+          // /api/forms/submit (FORM_RULES + project registry) — payout-wall-contest
+          // gets role:supporter + interest:justice-reform, no comms:/consent.
+          fields: { ...form, source_route: '/confessions/wall' },
+          additionalTags: [],
         }),
       });
       const result = await res.json();

--- a/src/components/flagship/QuickInquiryForm.tsx
+++ b/src/components/flagship/QuickInquiryForm.tsx
@@ -45,18 +45,22 @@ export function QuickInquiryForm({
         body: JSON.stringify({
           projectCode: projectCode || undefined,
           formType: "flagship-inquiry",
+          // The flagship `interest` select (Collaborate/Partner/Fund/Visit/Learn)
+          // + which flagship project they were on live in fields for human
+          // follow-up — they are NOT auto-promoted to role:partner/funder (the
+          // form captures no field that justifies it). Canonical
+          // source:/role:/project: tags are applied server-side by
+          // /api/forms/submit (FORM_RULES + project registry → role:supporter).
           fields: {
             firstName: firstName || name,
             lastName: lastName || undefined,
             email,
             message: message || undefined,
+            interest: interest || undefined,
+            flagship_project: projectName,
+            source_route: `flagship-page-${projectSlug}`,
           },
-          additionalTags: [
-            "Flagship Inquiry",
-            `Project: ${projectName}`,
-            `Interest: ${interest || "General"}`,
-            `Source: flagship-page-${projectSlug}`,
-          ],
+          additionalTags: [],
         }),
       });
 

--- a/src/components/forms/CSAInterestForm.tsx
+++ b/src/components/forms/CSAInterestForm.tsx
@@ -52,15 +52,12 @@ export function CSAInterestForm({
         body: JSON.stringify({
           projectCode: 'ACT-HV',
           formType: 'csa',
-          fields: formData,
-          additionalTags: [
-            'CSA Interest',
-            'The Harvest',
-            `Share: ${formData.shareType || 'Unspecified'}`,
-            `Context: ${contextLabel}`,
-            `Route: ${pathname}`,
-            ...additionalTags,
-          ],
+          // Provenance (page context/route) lives in fields, not tags — it is
+          // preserved on the Supabase row without polluting the GHL tag space.
+          // Canonical role:/interest:/source:/project: tags are applied server-side
+          // by /api/forms/submit (FORM_RULES + project registry).
+          fields: { ...formData, context: contextLabel, source_route: pathname },
+          additionalTags: [...additionalTags],
         }),
       });
 

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -66,16 +66,18 @@ export function ContactForm({
         body: JSON.stringify({
           projectCode,
           formType,
-          fields: formData,
-          additionalTags: [
-            'Contact Form',
-            'Website Inquiry',
-            `Context: ${contextLabel}`,
-            `Route: ${pathname}`,
-            ...(presetSource ? [`Source: ${presetSource}`] : []),
-            ...(presetContext ? [`Requested context: ${presetContext}`] : []),
-            ...additionalTags,
-          ],
+          // Provenance (page context/route + any ?source/?context UTM params)
+          // lives in fields, not tags — preserved on the Supabase row without
+          // polluting the GHL tag space. Canonical source:/project: tags are
+          // applied server-side by /api/forms/submit (FORM_RULES + project registry).
+          fields: {
+            ...formData,
+            context: contextLabel,
+            source_route: pathname,
+            ...(presetSource ? { preset_source: presetSource } : {}),
+            ...(presetContext ? { requested_context: presetContext } : {}),
+          },
+          additionalTags: [...additionalTags],
         }),
       });
 

--- a/src/components/forms/FarmStayForm.tsx
+++ b/src/components/forms/FarmStayForm.tsx
@@ -54,15 +54,12 @@ export function FarmStayForm({
         body: JSON.stringify({
           projectCode: 'ACT-BV',
           formType: 'farm-stay',
-          fields: formData,
-          additionalTags: [
-            'Farm Stay',
-            'Accommodation',
-            `Stay: ${formData.stayType || 'Unspecified'}`,
-            `Context: ${contextLabel}`,
-            `Route: ${pathname}`,
-            ...additionalTags,
-          ],
+          // Provenance (page context/route) lives in fields, not tags — it is
+          // preserved on the Supabase row without polluting the GHL tag space.
+          // Canonical role:/interest:/source:/project: tags are applied server-side
+          // by /api/forms/submit (FORM_RULES + project registry).
+          fields: { ...formData, context: contextLabel, source_route: pathname },
+          additionalTags: [...additionalTags],
         }),
       });
 

--- a/src/components/forms/NewsletterForm.tsx
+++ b/src/components/forms/NewsletterForm.tsx
@@ -48,15 +48,20 @@ export function NewsletterForm({
         body: JSON.stringify({
           projectCode: projectCode || 'ACT-IN', // Default to ACT Infrastructure
           formType: 'newsletter',
-          fields: { email },
+          // High-cardinality provenance (route/context) rides in fields → it is
+          // stored in the pending_form_submissions row but never reaches GHL
+          // (pushToGHL reads only email/phone/name). Keeps the audit trail
+          // without polluting the tag space.
+          fields: { email, signupRoute: pathname, signupContext: contextLabel, signupPlacement: source },
+          // Namespaced provenance only (taxonomy: no ad-hoc flat tags). The
+          // signup channel (source:website), comms list, project: and tier are
+          // seated server-side in /api/forms/submit; here we add only the
+          // placement sub-source + optional page/story/audience context.
           additionalTags: [
-            'Newsletter',
-            `Context: ${contextLabel}`,
-            `Route: ${pathname}`,
-            `Source: ${source}`,
-            ...(projectSlug ? [`Project: ${projectSlug}`] : []),
-            ...(storySlug ? [`Story: ${storySlug}`] : []),
-            ...(audience ? [`Audience: ${audience}`] : []),
+            `source:website-${source}`,
+            ...(projectSlug ? [`source:page:${projectSlug}`] : []),
+            ...(storySlug ? [`source:story:${storySlug}`] : []),
+            ...(audience ? [`interest:${audience}`] : []),
             ...additionalTags,
           ],
         }),

--- a/src/components/forms/ResidencyForm.tsx
+++ b/src/components/forms/ResidencyForm.tsx
@@ -55,16 +55,12 @@ export function ResidencyForm({
         body: JSON.stringify({
           projectCode: 'ACT-AS',
           formType: 'residency',
-          fields: formData,
-          additionalTags: [
-            'Art Residency',
-            'Artist Application',
-            `Residency: ${formData.residencyType || 'Unspecified'}`,
-            `Practice: ${formData.practiceType || 'Unspecified'}`,
-            `Context: ${contextLabel}`,
-            `Route: ${pathname}`,
-            ...additionalTags,
-          ],
+          // Provenance (page context/route) lives in fields, not tags — it is
+          // preserved on the Supabase row without polluting the GHL tag space.
+          // Canonical role:/interest:/source:/project: tags are applied server-side
+          // by /api/forms/submit (FORM_RULES + project registry).
+          fields: { ...formData, context: contextLabel, source_route: pathname },
+          additionalTags: [...additionalTags],
         }),
       });
 


### PR DESCRIPTION
## What

P1 of the whole-system forms → GHL tag-contract alignment. Brings act.place's form submissions onto ACT's canonical GHL taxonomy (`source:`/`role:`/`interest:`/`project:`/`comms:` namespaces) instead of flat/drifting tags.

**Two commits:**
- `a807396` — newsletter signup → `source:website` · `role:supporter` · `newsletter_consent=Yes` · `comms:act-newsletter`
- `496e826` — the 5 inquiry forms (`csa`, `farm-stay`, `residency`, `payout-wall-contest`, `flagship-inquiry`) + `ContactForm` → canonical `role:`/`interest:`/`source:` set, server-side via `FORM_RULES` in `/api/forms/submit`. Page provenance moves to `fields` (off the tag space).

## Key contract points
- Identity tags (`role:`/`interest:`/`source:`/`project:`) never trigger a send — only the newsletter formType seats `comms:act-newsletter` + `newsletter_consent=Yes` (Spam Act gate).
- `project:` tag derives from the page's existing `projectCode` (PR #51 mechanism, unchanged here).

## Spec
`act-global-infrastructure/thoughts/shared/plans/2026-06-08-whole-system-forms-tag-alignment.md` (§A, rulings R1).

## After merge
Production deploy (deploy.yml) → one live newsletter tracer → verify canonical tags land in the "A Curious Tractor" GHL location before any automation is switched on.