### PR TITLE
Editorial: consent-gated serving + world-class article reading experience

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -53,6 +53,12 @@ const nextConfig = {
         protocol: "https",
         hostname: "www.empathyledger.com",
       },
+      {
+        // The 2026-08 media sync emits apex-domain URLs; both hosts serve
+        // the same Empathy Ledger media API.
+        protocol: "https",
+        hostname: "empathyledger.com",
+      },
     ],
   },
   eslint: {

--- a/src/app/api/enrichment-review/[id]/route.ts
+++ b/src/app/api/enrichment-review/[id]/route.ts
@@ -8,11 +8,15 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseServerClient } from '@/lib/supabase/server';
+import { requireInternal } from '@/lib/auth/require-internal';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   try {
     const { id } = await params;
 
@@ -55,6 +59,9 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   try {
     const { id } = await params;
     const body = await request.json();
@@ -115,6 +122,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   try {
     const { id } = await params;
 

--- a/src/app/api/knowledge/extract/route.ts
+++ b/src/app/api/knowledge/extract/route.ts
@@ -12,6 +12,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { requireInternal } from '@/lib/auth/require-internal';
 
 const EXTRACTION_PROMPT = `You are analyzing content from ACT's daily tools to extract actionable knowledge for their Living Wiki.
 
@@ -54,6 +55,9 @@ IMPORTANT:
 - If confidence < 0.5, set isKnowledge to false`;
 
 export async function POST(request: NextRequest) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   try {
     const body = await request.json();
     const { queueId, sourceTitle, content } = body;
@@ -237,6 +241,9 @@ function parseAIResponse(aiResponse: string): any {
  * GET endpoint to check extraction queue status
  */
 export async function GET(request: NextRequest) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   try {
     const { createClient } = await import('@supabase/supabase-js');
     const supabase = createClient(

--- a/src/app/api/knowledge/scan-gmail/route.ts
+++ b/src/app/api/knowledge/scan-gmail/route.ts
@@ -6,10 +6,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { runGmailScan } from '@/lib/knowledge/gmail-scanner';
 import { getSupabaseServerClient } from '@/lib/supabase/server';
+import { requireInternal } from '@/lib/auth/require-internal';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(request: NextRequest) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   try {
     const body = await request.json();
     const { userEmail } = body;
@@ -44,7 +48,10 @@ export async function POST(request: NextRequest) {
 /**
  * GET /api/knowledge/scan-gmail - Get info about Gmail scanner
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   const supabase = getSupabaseServerClient();
 
   if (!supabase) {

--- a/src/app/api/knowledge/scan-notion/route.ts
+++ b/src/app/api/knowledge/scan-notion/route.ts
@@ -14,16 +14,14 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { NotionScanner } from '@/lib/knowledge/notion-scanner';
+import { requireInternal } from '@/lib/auth/require-internal';
 
 export async function POST(request: NextRequest) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   try {
     console.log('🚀 Starting Notion scan...');
-
-    // Optional: Check authentication
-    // const session = await getServerSession();
-    // if (!session) {
-    //   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    // }
 
     // Create scanner
     const scanner = new NotionScanner();
@@ -75,6 +73,9 @@ export async function POST(request: NextRequest) {
  * GET endpoint to check scan status
  */
 export async function GET(request: NextRequest) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   try {
     const { createClient } = await import('@supabase/supabase-js');
     const supabase = createClient(

--- a/src/app/api/registry/route.ts
+++ b/src/app/api/registry/route.ts
@@ -1,9 +1,10 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import {
   fetchRegistryFromSources,
   listRegistryFromSupabase,
   syncRegistryToSupabase,
 } from "../../../lib/registry/registry";
+import { requireInternal } from "@/lib/auth/require-internal";
 
 const parseNumber = (value: string | null) => {
   if (!value) return undefined;
@@ -19,7 +20,9 @@ const resolveStatus = (value: string | null) => {
 const requireSyncToken = (request: Request) => {
   const expectedToken = process.env.REGISTRY_SYNC_TOKEN;
   if (!expectedToken) {
-    return null;
+    // No sync token configured: this must not mean "open to everyone".
+    // The caller falls back to the internal gate instead.
+    return "Sync token not configured.";
   }
 
   const authHeader = request.headers.get("authorization") ?? "";
@@ -82,10 +85,15 @@ export async function GET(request: Request) {
   }
 }
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+  // Two ways in: a configured REGISTRY_SYNC_TOKEN (external sync callers) or
+  // the internal token/cookie (admin tooling). Anonymous callers get neither.
   const authError = requireSyncToken(request);
   if (authError) {
-    return NextResponse.json({ error: authError }, { status: 401 });
+    const denied = requireInternal(request);
+    if (denied) {
+      return NextResponse.json({ error: authError }, { status: 401 });
+    }
   }
 
   try {

--- a/src/app/api/subscriptions/discover/route.ts
+++ b/src/app/api/subscriptions/discover/route.ts
@@ -6,11 +6,15 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { requireInternal } from '@/lib/auth/require-internal';
 
 const ACT_PLACEMAT_API_URL = process.env.ACT_PLACEMAT_API_URL || 'http://localhost:3002';
 const ACT_PLACEMAT_API_KEY = process.env.ACT_PLACEMAT_API_KEY;
 
 export async function POST(request: NextRequest) {
+  const denied = requireInternal(request);
+  if (denied) return denied;
+
   try {
     // Extract query parameters and body
     const { searchParams } = new URL(request.url);

--- a/src/app/api/v1/ask/route.ts
+++ b/src/app/api/v1/ask/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { unifiedRAG } from '@/lib/ai-intelligence/unified-rag-service';
 import type { AnalysisTier } from '@/lib/ai-intelligence/multi-provider-ai';
+import { requireInternal } from '@/lib/auth/require-internal';
 
 // CORS headers for cross-origin requests (if needed)
 const corsHeaders = {
@@ -27,6 +28,12 @@ export async function OPTIONS() {
 
 // Main query handler
 export async function POST(req: NextRequest) {
+  // The public /ask page is held pending a cost/safety/injection review
+  // (config/launch-redirects.cjs); the API stays internal until that review
+  // passes, since every call spends real money on embeddings + generation.
+  const denied = requireInternal(req);
+  if (denied) return denied;
+
   try {
     // Parse request body
     const body = await req.json();

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -12,6 +12,12 @@ import {
 } from "../../../lib/empathy-ledger-editorial";
 import { articleJsonLd, breadcrumbJsonLd, pageMetadata } from "@/lib/seo/site";
 import {
+  cleanAltText,
+  prepareArticleHtml,
+  readingTimeMinutes,
+} from "@/lib/editorial/article-html";
+import { ReadingProgress } from "@/components/editorial/ReadingProgress";
+import {
   fieldsForArticle,
   projectSlugDestination,
   relatedArticles,
@@ -92,6 +98,8 @@ export default async function BlogPostPage({
 
   const content = post.content || "";
   const looksLikeHtml = /<\/?[a-z][\s\S]*>/i.test(content);
+  const preparedHtml = looksLikeHtml ? prepareArticleHtml(content) : null;
+  const readingMinutes = readingTimeMinutes(content);
   const lede = shortLede(post.excerpt);
   const dateLabel = publishedDateLabel(post.publishedAt);
   const hasHero = !!post.featuredImageUrl;
@@ -116,10 +124,18 @@ export default async function BlogPostPage({
   ];
 
   // Gallery photos = everything from EL media except the featured image (which
-  // already runs at the top as the hero) and duplicates.
+  // already runs at the top as the hero) and duplicates. The sync writes alt
+  // text under alt_text (older shapes used alt), and most of it is Webflow
+  // filename junk — cleanAltText decides whether any of it is a real
+  // description.
   const gallery = (post.media?.photoPreviews || [])
     .filter((photo) => !!photo.url && photo.url !== post.featuredImageUrl)
-    .slice(0, 8);
+    .slice(0, 8)
+    .map((photo) => ({
+      url: photo.url,
+      alt: cleanAltText(photo.alt ?? photo.alt_text ?? photo.title),
+      caption: photo.caption ?? null,
+    }));
 
   // Suggested reading, related first.
   //
@@ -166,7 +182,10 @@ export default async function BlogPostPage({
           { name: post.title, path: `/blog/${post.slug}` },
         ])}
       />
-      {/* , , ,  HERO: full-bleed image with title + meta overlay , , ,  */}
+      <ReadingProgress />
+      {/* HERO: full-bleed image with title + meta overlay. Articles without a
+          featured image get a typographic cover — deep olive field with a low
+          clay glow — instead of a bare black rectangle. */}
       <section className="full-bleed relative min-h-[60vh] w-full overflow-hidden bg-[#11110F] md:min-h-[75vh]">
         {hasHero ? (
           <Image
@@ -177,8 +196,22 @@ export default async function BlogPostPage({
             className="object-cover"
             priority
           />
-        ) : null}
-        <div className="absolute inset-0 bg-gradient-to-b from-black/25 via-black/45 to-black/80" />
+        ) : (
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-[linear-gradient(150deg,#33402F_0%,#222B21_55%,#161B15_100%)]"
+          >
+            <div className="absolute inset-0 bg-[radial-gradient(ellipse_60%_50%_at_18%_88%,rgba(196,132,92,0.28),transparent_70%)]" />
+            <span className="absolute -bottom-24 right-[-4%] select-none font-[var(--font-display)] text-[38vw] font-light italic leading-none text-[#F3EBDD]/[0.05] md:text-[26vw]">
+              {post.title.charAt(0)}
+            </span>
+          </div>
+        )}
+        {hasHero ? (
+          <div className="absolute inset-0 bg-gradient-to-b from-black/25 via-black/45 to-black/80" />
+        ) : (
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/40" />
+        )}
         <div className="relative z-10 mx-auto flex min-h-[60vh] max-w-[1000px] flex-col justify-end px-6 pb-16 pt-32 md:min-h-[75vh] md:px-10 md:pb-24 md:pt-40">
           <Link
             href="/stories"
@@ -186,7 +219,7 @@ export default async function BlogPostPage({
           >
             <span aria-hidden="true">&larr;</span> All stories
           </Link>
-          <h1 className="mt-6 font-[var(--font-display)] text-[clamp(2.2rem,5vw,4.2rem)] font-semibold leading-[1.05] text-[#F3EBDD]">
+          <h1 className="mt-6 font-[var(--font-display)] text-[clamp(2.2rem,5vw,4.2rem)] font-light leading-[1.08] text-[#F3EBDD]">
             {post.title}
           </h1>
           {lede ? (
@@ -208,17 +241,23 @@ export default async function BlogPostPage({
                 <span>{post.articleType}</span>
               </>
             ) : null}
+            {readingMinutes ? (
+              <>
+                <span aria-hidden="true" className="text-[#CFA16B]/40">·</span>
+                <span>{readingMinutes} min read</span>
+              </>
+            ) : null}
           </div>
         </div>
       </section>
 
-      {/* , , ,  BODY: long-form article in a readable measure , , ,  */}
+      {/* BODY: long-form article in a readable measure */}
       <section className="bg-[#FBF6EC] px-6 py-20 md:px-10 md:py-28">
         <article className="mx-auto max-w-[720px]">
           {content ? (
-            <div className="rich-text prose prose-lg max-w-none prose-headings:font-[var(--font-display)] prose-headings:text-[var(--we-olive)] prose-p:text-[17px] prose-p:leading-[1.8] prose-p:text-[var(--we-brown)] prose-a:text-forest prose-a:no-underline hover:prose-a:underline prose-strong:text-[var(--we-olive)] prose-blockquote:border-l-[3px] prose-blockquote:border-[#CFA16B] prose-blockquote:bg-[#F3EBDD]/50 prose-blockquote:py-1 prose-blockquote:italic prose-img:rounded-[20px]">
-              {looksLikeHtml ? (
-                <div dangerouslySetInnerHTML={{ __html: content }} />
+            <div className="rich-text">
+              {preparedHtml ? (
+                <div dangerouslySetInnerHTML={{ __html: preparedHtml }} />
               ) : (
                 <ReactMarkdown>{content}</ReactMarkdown>
               )}
@@ -232,7 +271,7 @@ export default async function BlogPostPage({
         </article>
       </section>
 
-      {/* , , ,  GALLERY: nice big photos from the field , , ,  */}
+      {/* GALLERY: field photographs */}
       {gallery.length > 0 && (
         <section className="full-bleed bg-[#F6F1E7] px-6 py-20 md:px-10 md:py-28">
           <div className="mx-auto max-w-[1300px]">
@@ -287,7 +326,7 @@ export default async function BlogPostPage({
         </section>
       )}
 
-      {/* , , ,  AUTHOR + RELATED PROJECTS , , ,  */}
+      {/* AUTHOR + CONNECTED FIELDS */}
       <section className="bg-[#FBF6EC] px-6 py-16 md:px-10 md:py-20">
         <div className="mx-auto max-w-[720px] space-y-8">
           {post.authorName ? (
@@ -345,7 +384,7 @@ export default async function BlogPostPage({
         </div>
       </section>
 
-      {/* , , ,  CTAS , , ,  */}
+      {/* CTAS */}
       <section className="full-bleed bg-[var(--we-olive)] px-6 py-16 md:px-10 md:py-24">
         <div className="mx-auto flex max-w-[820px] flex-col items-center gap-6 text-center">
           <p className="font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.35em] text-[#CFA16B]">
@@ -379,7 +418,7 @@ export default async function BlogPostPage({
         </div>
       </section>
 
-      {/* , , ,  SUGGESTED READING , , ,  */}
+      {/* SUGGESTED READING */}
       {suggested.length > 0 && (
         <section className="full-bleed bg-[#FBF6EC] px-6 py-20 md:px-10 md:py-28">
           <div className="mx-auto max-w-[1200px]">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -195,22 +195,58 @@ background-image: url("data:image/svg+xml,%3Csvg width='100' height='100' viewBo
 background-repeat: repeat;
 }
 
+/* ------------------------------------------------------------------ */
+/* Article body (.rich-text) — the long-form reading experience.       */
+/*                                                                     */
+/* The corpus is exported HTML from two ancestries (Webflow richtext   */
+/* figures, Storipress data-type divs), so these rules style the       */
+/* markup those exporters actually emit — including full-bleed figure  */
+/* breakouts from a 720px column and intrinsic-ratio video figures.    */
+/* prepareArticleHtml() in src/lib/editorial/article-html.ts strips    */
+/* scripts / stray h1s / junk alts before this CSS ever sees it.       */
+/* ------------------------------------------------------------------ */
+
 .rich-text {
-  line-height: 1.8;
+  font-family: var(--font-body);
+  font-size: 1.0625rem;
+  line-height: 1.85;
+  color: var(--we-brown);
+}
+
+@media (min-width: 768px) {
+  .rich-text {
+    font-size: 1.125rem;
+  }
 }
 
 .rich-text h2,
-.rich-text h3 {
-  margin-top: 2rem;
-  margin-bottom: 0.75rem;
+.rich-text h3,
+.rich-text h4 {
   font-family: var(--font-display);
-  color: var(--site-ink);
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--we-olive);
+}
+
+.rich-text h2 {
+  margin: 2.75rem 0 1rem;
+  font-size: clamp(1.5rem, 2.6vw, 1.9rem);
+}
+
+.rich-text h3 {
+  margin: 2.25rem 0 0.85rem;
+  font-size: clamp(1.25rem, 2.1vw, 1.45rem);
+}
+
+.rich-text h4 {
+  margin: 2rem 0 0.75rem;
+  font-size: 1.125rem;
 }
 
 .rich-text p,
 .rich-text ul,
 .rich-text ol {
-  margin: 1rem 0;
+  margin: 1.15rem 0;
 }
 
 .rich-text ul {
@@ -223,9 +259,139 @@ background-repeat: repeat;
   padding-left: 1.5rem;
 }
 
+.rich-text li::marker {
+  color: var(--site-clay-text);
+}
+
 .rich-text a {
   color: var(--site-green);
   text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--site-green) 40%, transparent);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 150ms ease;
+}
+
+.rich-text a:hover {
+  text-decoration-color: var(--site-green);
+}
+
+.rich-text strong {
+  color: var(--we-olive);
+}
+
+.rich-text sup {
+  font-size: 0.7em;
+}
+
+.rich-text blockquote {
+  margin: 2.25rem 0;
+  padding: 1rem 1.5rem;
+  border-left: 3px solid var(--site-clay);
+  background: rgba(227, 212, 186, 0.35);
+  border-radius: 0 16px 16px 0;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.2em;
+  line-height: 1.55;
+  color: var(--we-olive);
+}
+
+.rich-text blockquote p {
+  margin: 0.5rem 0;
+}
+
+.rich-text hr {
+  border: none;
+  width: 64px;
+  height: 2px;
+  margin: 3rem auto;
+  background: var(--site-clay);
+  opacity: 0.55;
+}
+
+/* --- Figures and images ------------------------------------------- */
+
+.rich-text figure {
+  margin: 2.5rem 0;
+}
+
+.rich-text img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 20px;
+}
+
+.rich-text figcaption,
+.rich-text .caption-text {
+  margin-top: 0.65rem;
+  font-family: var(--font-sans);
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: 0.01em;
+  color: var(--we-warm-brown);
+}
+
+.rich-text figcaption:empty {
+  display: none;
+}
+
+/* Webflow's fullwidth figures break out of the 720px measure. The figure's
+   containing block is the article column, so margin-left:50% lands its left
+   edge on the column centre (= page centre, the column is mx-auto) and the
+   translate pulls it back by half its own width. Capped below the 1200px
+   section container so a breakout never collides with the page frame. */
+.rich-text figure.w-richtext-align-fullwidth {
+  width: min(calc(100vw - 3rem), 1100px);
+  margin-left: 50%;
+  transform: translateX(-50%);
+}
+
+.rich-text figure.w-richtext-align-fullwidth img {
+  border-radius: 24px;
+}
+
+.rich-text figure.w-richtext-align-fullwidth figcaption,
+.rich-text figure.w-richtext-align-fullwidth .caption-text {
+  text-align: center;
+}
+
+.rich-text figure.w-richtext-align-center {
+  margin-inline: auto;
+  max-width: 100%;
+}
+
+/* Webflow video figures carry their ratio as inline padding-bottom on the
+   figure and a bare iframe inside; without these rules they collapse to
+   zero height. The inline padding percentage resolves against the 720px
+   column even when the figure breaks out to 1100px, which letterboxes the
+   video — so it is overridden with a real aspect-ratio. (Storipress/
+   Descript embeds ship their own inline intrinsic-ratio wrappers and need
+   nothing.) */
+.rich-text figure[class*="w-richtext-figure-type-video"] {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  padding-bottom: 0 !important;
+  overflow: hidden;
+  border-radius: 20px;
+}
+
+.rich-text figure[class*="w-richtext-figure-type-video"] iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.rich-text iframe {
+  max-width: 100%;
+}
+
+.rich-text div[data-type="embed"],
+.rich-text div[data-rt-embed-type] {
+  margin: 2.5rem 0;
 }
 
 .site-shell {

--- a/src/components/editorial/ReadingProgress.tsx
+++ b/src/components/editorial/ReadingProgress.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Thin clay progress rule pinned to the viewport top while reading an
+ * article. scaleX on a full-width bar rather than width so updates never
+ * trigger layout; scroll events are coalesced through rAF.
+ */
+export function ReadingProgress() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    let raf = 0;
+    const update = () => {
+      const doc = document.documentElement;
+      const max = doc.scrollHeight - window.innerHeight;
+      setProgress(max > 0 ? Math.min(1, window.scrollY / max) : 0);
+    };
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(update);
+    };
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-x-0 top-0 z-50 h-[3px]"
+    >
+      <div
+        className="h-full origin-left bg-[var(--site-clay)]"
+        style={{ transform: `scaleX(${progress})` }}
+      />
+    </div>
+  );
+}

--- a/src/components/stories/StoryScroll.tsx
+++ b/src/components/stories/StoryScroll.tsx
@@ -133,12 +133,6 @@ function getSnapshotMedia(sourceProjectSlug: string, kind: 'image' | 'video', li
     .slice(0, limit);
 }
 
-function tagLabel(block: Extract<StoryBlock, { kind: 'el-gallery' | 'el-video-gallery' }>) {
-  const all = block.tagQuery.all || [];
-  const any = block.tagQuery.any || [];
-  return [...all, ...any].slice(0, 5).join(' / ');
-}
-
 function BlockView({
   block,
   story,
@@ -323,9 +317,6 @@ function BlockView({
                 {block.description}
               </p>
             ) : null}
-            <p className="mt-4 font-mono text-xs text-[var(--site-muted)]">
-              EL query tags: {tagLabel(block)}
-            </p>
             <div className="mt-10 grid gap-4 md:grid-cols-3">
               {items.map((item) => {
                 const src = mediaImageSource(item);
@@ -375,9 +366,6 @@ function BlockView({
                 {block.description}
               </p>
             ) : null}
-            <p className="mt-4 font-mono text-xs text-[#FAFAF7]/45">
-              EL query tags: {tagLabel(block)}
-            </p>
             <div className="mt-10 grid gap-5 md:grid-cols-2">
               {items.map((item) => (
                 <a

--- a/src/lib/editorial/article-html.ts
+++ b/src/lib/editorial/article-html.ts
@@ -1,0 +1,74 @@
+/**
+ * Server-side preparation for Empathy Ledger article HTML.
+ *
+ * 24 of the 26 syndicated articles arrive as raw exported HTML (Webflow and
+ * Storipress vintages), not markdown. The markup is structurally sound — the
+ * embeds carry their own intrinsic-ratio wrappers inline — but it ships three
+ * defects that must not reach the page:
+ *
+ *  - `<script>` tags for the old Storipress analytics loader. React's
+ *    innerHTML never executes them, but they don't belong in the DOM at all.
+ *  - stray `<h1>`s inside body copy (8 across the corpus), which duplicate
+ *    the page H1 the hero renders.
+ *  - Webflow's reserved alt placeholder (`__wf_reserved_inherit`, 115
+ *    occurrences) and filename-shaped alts, which read as junk in a screen
+ *    reader. An empty alt (decorative) is the honest fallback when no real
+ *    description exists.
+ *
+ * Everything visual (full-bleed figures, captions, blockquotes, video ratio
+ * for Webflow figures) is handled by the .rich-text CSS, not by rewriting
+ * markup here. Keep this transform minimal: it runs on trusted first-party
+ * content from Empathy Ledger, and every regex added is a new way to corrupt
+ * an article.
+ */
+
+const SCRIPT_TAG = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+const BODY_H1_OPEN = /<h1(\s[^>]*)?>/gi;
+const BODY_H1_CLOSE = /<\/h1>/gi;
+const ALT_ATTR = /\balt=(["'])(.*?)\1/gi;
+
+/**
+ * Junk-alt detection, same shape as StoryScroll's cleanAlt: Webflow reserved
+ * placeholders, bare filenames, and `img_1234`-style machine names all count
+ * as "no alt was ever written".
+ */
+export function cleanAltText(value: string | null | undefined, fallback = ""): string {
+  if (!value) return fallback;
+  const cleaned = value
+    .replace(/^Image:\s*/i, "")
+    .replace(/^Video:\s*/i, "")
+    .trim();
+  if (!cleaned) return fallback;
+  if (/^__wf_reserved/i.test(cleaned)) return fallback;
+  if (/^[\w().\-\s]+?\.(jpe?g|png|webp|gif|mp4|mov|webm)$/i.test(cleaned)) return fallback;
+  if (/^(img|image|video|file|photo)[-_ ]?\d+/i.test(cleaned)) return fallback;
+  return cleaned;
+}
+
+export function prepareArticleHtml(html: string): string {
+  return html
+    .replace(SCRIPT_TAG, "")
+    .replace(BODY_H1_OPEN, "<h2$1>")
+    .replace(BODY_H1_CLOSE, "</h2>")
+    .replace(ALT_ATTR, (_match, quote: string, value: string) => {
+      // HTML-decode the two entities that appear in these alts before
+      // judging them; re-encode is unnecessary because junk becomes "".
+      const decoded = value.replace(/&quot;/g, '"').replace(/&amp;/g, "&");
+      const cleaned = cleanAltText(decoded);
+      return cleaned === decoded ? `alt=${quote}${value}${quote}` : `alt=${quote}${cleaned}${quote}`;
+    });
+}
+
+/**
+ * Rounded-up minutes at 220 wpm over the tag-stripped text. Returns null under
+ * a minute of reading — a "1 min read" badge on a stub is noise, not signal.
+ */
+export function readingTimeMinutes(html: string): number | null {
+  const text = html
+    .replace(SCRIPT_TAG, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&[a-z#0-9]+;/gi, " ");
+  const words = text.split(/\s+/).filter(Boolean).length;
+  if (words < 220) return null;
+  return Math.ceil(words / 220);
+}

--- a/src/lib/empathy-ledger-editorial.ts
+++ b/src/lib/empathy-ledger-editorial.ts
@@ -35,10 +35,15 @@ export interface EditorialArticle {
   media: {
     photoCount: number;
     videoCount: number;
+    // The sync emits { url, title, alt_text }; older shapes carried
+    // { url, alt, caption }. Declare the union of what actually arrives so
+    // consumers stop reading fields that are never there.
     photoPreviews: Array<{
       url: string;
-      alt: string | null;
-      caption: string | null;
+      alt?: string | null;
+      alt_text?: string | null;
+      title?: string | null;
+      caption?: string | null;
     }>;
     videoPreviews: Array<{
       url: string;
@@ -145,6 +150,8 @@ function applyConsentGate(snapshot: EditorialSnapshot): EditorialSnapshot {
 
 const SNAPSHOT = applyConsentGate(editorialSnapshot as unknown as EditorialSnapshot);
 
+const BAKED_BY_SLUG = new Map(SNAPSHOT.articles.map((article) => [article.slug, article]));
+
 /**
  * Editorial read live from Empathy Ledger, falling back to the copy baked at
  * build time.
@@ -230,12 +237,24 @@ function normaliseProjectEditorial(
  * not make the data arrive. So the fields are filled here, at the one place live
  * data enters, rather than guarded at each of the dozens of places they are read.
  *
- * Defaults match what the generator produces for the same article, so a page
- * cannot tell whether it is rendering live or baked. `localPath` is derived the
- * same way the sync script derives it, because a URL on this site is this site's
- * concern and not something Empathy Ledger should be asked to know.
+ * Missing fields fall back to the BAKED copy of the same article first, and
+ * only then to empty defaults. Nulling them out was itself a serving bug: the
+ * live list omits `content`, so whenever the live read succeeded every article
+ * page rendered "this story has no public body yet" while the full body sat in
+ * the snapshot. Live wins field-by-field where it actually sends a value; the
+ * baked article fills the rest. An article withdrawn at the source cannot leak
+ * back in through this merge, because it is absent from the live list entirely
+ * and this function never runs for it.
+ *
+ * `localPath` is derived the same way the sync script derives it, because a URL
+ * on this site is this site's concern and not something Empathy Ledger should
+ * be asked to know.
  */
-function normaliseLiveArticle(article: Partial<EditorialArticle> & { slug: string }): EditorialArticle {
+function normaliseLiveArticle(liveArticle: Partial<EditorialArticle> & { slug: string }): EditorialArticle {
+  const baked = BAKED_BY_SLUG.get(liveArticle.slug);
+  // JSON.parse never produces undefined values, so spreading the live article
+  // last overrides exactly the fields the API actually sent.
+  const article = { ...baked, ...liveArticle };
   return {
     ...article,
     localPath: article.localPath ?? `/blog/${article.slug}`,

--- a/src/lib/empathy-ledger-editorial.ts
+++ b/src/lib/empathy-ledger-editorial.ts
@@ -4,6 +4,7 @@ import { cache } from 'react';
 
 import { fetchEmpathyLedgerJson } from '@/lib/empathy-ledger-runtime';
 import editorialSnapshot from '@/data/empathy-ledger-editorial.generated.json';
+import withdrawnTombstone from '../../config/withdrawn-editorial.json';
 
 export interface EditorialArticle {
   id: string;
@@ -94,9 +95,55 @@ interface EditorialSnapshot {
   articles: EditorialArticle[];
 }
 
-const SNAPSHOT = editorialSnapshot as unknown as EditorialSnapshot;
-
 const SITE_SLUG = process.env.EMPATHY_LEDGER_SITE_SLUG || 'act-regenerative-studio';
+
+/**
+ * Consent gate, applied to BOTH the baked snapshot and the live read.
+ *
+ * The sync script enforces the withdrawal tombstone, the attribution rule and
+ * visibility when it bakes the snapshot — but since 01091b9 the live read wins
+ * over the baked copy, so a rule enforced only at build time is a rule the
+ * production site does not have. Everything the sync withholds must be
+ * withheld again here, at the one place both paths converge.
+ */
+const WITHDRAWN = {
+  slugs: new Set<string>(Array.isArray(withdrawnTombstone.slugs) ? withdrawnTombstone.slugs : []),
+  storytellerIds: new Set<string>(
+    Array.isArray(withdrawnTombstone.storytellerIds) ? withdrawnTombstone.storytellerIds : []
+  ),
+};
+
+function passesConsentGate(article: EditorialArticle): boolean {
+  if (WITHDRAWN.slugs.has(article.slug)) return false;
+  const storytellerId = article.storyteller?.id;
+  if (storytellerId && WITHDRAWN.storytellerIds.has(storytellerId)) return false;
+
+  // A person-voiced piece (one with a storyteller) must never ship without a
+  // resolvable name: publishing it under a blank or generic byline erases the
+  // storyteller. Same rule as scripts/sync-el-editorial.mjs.
+  const resolvedAuthor = article.authorName || article.storyteller?.displayName || '';
+  if (article.storyteller && !resolvedAuthor) return false;
+
+  // The live content-hub response may omit visibility entirely; absent is not
+  // the same as restricted, so only an explicit non-public value withholds.
+  if (article.visibility && article.visibility !== 'public') return false;
+
+  return true;
+}
+
+function applyConsentGate(snapshot: EditorialSnapshot): EditorialSnapshot {
+  const articles = snapshot.articles.filter(passesConsentGate);
+  if (articles.length === snapshot.articles.length) return snapshot;
+  const projectArticleCounts: Record<string, number> = {};
+  for (const article of articles) {
+    for (const slug of article.relatedProjectSlugs || []) {
+      projectArticleCounts[slug] = (projectArticleCounts[slug] || 0) + 1;
+    }
+  }
+  return { ...snapshot, articles, articleCount: articles.length, projectArticleCounts };
+}
+
+const SNAPSHOT = applyConsentGate(editorialSnapshot as unknown as EditorialSnapshot);
 
 /**
  * Editorial read live from Empathy Ledger, falling back to the copy baked at
@@ -252,7 +299,9 @@ export function getBakedEditorialSnapshot(): EditorialSnapshot {
 
 export const getEditorialSnapshot = cache(async (): Promise<EditorialSnapshot> => {
   const live = await fetchEditorialLive();
-  return live ?? SNAPSHOT;
+  // The gate runs on the live result too: a withdrawal recorded locally must
+  // hold even when the source is still serving the article.
+  return live ? applyConsentGate(live) : SNAPSHOT;
 });
 
 export const getSiteEditorialArticles = cache(


### PR DESCRIPTION
## What this does

Two commits from the launch review of the Empathy Ledger → editorial pipeline.

### 1. Consent + auth hardening (`fix`)
- The live Empathy Ledger read (01091b9) bypassed every rule the build-time sync enforces. `getEditorialSnapshot()` now applies the withdrawal tombstone (`config/withdrawn-editorial.json`), the person-voiced-attribution rule, and explicit visibility on **both** the live and baked paths — a locally recorded withdrawal now holds even while the source still serves the article.
- `requireInternal` added to the ungated spending/internal API routes: `/api/v1/ask` POST (held pending safety review, spends money per call), `enrichment-review/[id]` (all methods, matching its gated sibling), `knowledge/extract|scan-gmail|scan-notion` (POSTs trigger paid scans, GETs exposed the internal queue), `subscriptions/discover`, and `/api/registry` POST no longer fails open when `REGISTRY_SYNC_TOKEN` is unset.

### 2. Article reading experience (`feat`)
The live `/blog/[slug]` renderer was written against `@tailwindcss/typography`, which was never installed — 24 of 26 articles arrive as raw Webflow/Storipress HTML and rendered at browser defaults: unstyled figures, collapsed video embeds, junk alt text, black-box heroes.

- **`prepareArticleHtml`** (new `src/lib/editorial/article-html.ts`): strips dead analytics scripts, demotes 8 stray body `<h1>`s, cleans 119 Webflow junk alts (keeps the 37 real ones)
- **Full `.rich-text` ruleset** on brand tokens: Fraunces headings, serif body at proper measure, clay blockquotes/rules, styled captions, full-bleed figure breakouts (to 1100px from the 720px column), aspect-ratio fix for Webflow video figures (inline padding resolved against the column and letterboxed breakout videos)
- **Live/baked article merge**: the live content-hub list omits `content` and eight other fields; nulling them served *body-less articles* whenever the live read won. Missing fields now fall back to the baked article by slug. A withdrawn article cannot leak back through the merge — it is absent from the live list entirely.
- **Typographic hero cover** (olive gradient, ghosted Fraunces initial) for the 8 articles with no featured image
- **Reading furniture**: scroll-progress rule + min-read estimate
- Removed "EL query tags" debug text from public StoryScroll galleries
- Allow apex `empathyledger.com` in `next/image` (the 2026-08 sync emits apex URLs)

## Verification

- `tsc --noEmit` green; `check:copy` green; `vitest run` 22 passed / 0 failed against committed data
- Browser-verified on dev across four representative articles: full-bleed figures (`the-spirit-must-be-strong`), Descript embeds at 640×360 (`historys-wounds-and-tomorrows-possibilities`), Storipress/YouTube/hr treatment (`edition-1-sowing-seeds-of-connection-2`), Webflow video figure at 16:9 (`beyond-bars-joe-kwons-journey-to-reshape-society`), typographic hero (`powering-change-a-curious-tractors-journey`)
- Mobile 375px: no horizontal overflow, zero collapsed figures, zero broken images

## Preview checklist

- [ ] `/blog/the-spirit-must-be-strong` — full-bleed figures pace through the narrative
- [ ] `/blog/powering-change-a-curious-tractors-journey` — typographic hero cover
- [ ] `/blog/historys-wounds-and-tomorrows-possibilities` — Descript embeds render with height

🤖 Generated with [Claude Code](https://claude.com/claude-code)