### PR TITLE
Permanent closure, thirty redirect chains flattened, and two decisions recorded

### DIFF
--- a/config/launch-redirects.cjs
+++ b/config/launch-redirects.cjs
@@ -24,11 +24,11 @@ const launchRedirects = [
     permanent: true,
   },
 
-  // Legacy public-site routes. /seeds and /action stay pointed at /projects,
-  // their durable home, and ride its temporary closure redirect; see the note
-  // on the deleted-entries block below.
-  { source: "/seeds", destination: "/projects", permanent: true },
-  { source: "/action", destination: "/projects", permanent: true },
+  // Legacy public-site routes. /seeds and /action used to point at /projects and
+  // ride its closure redirect, which cost every visitor a second hop. The closure
+  // is permanent (2026-08-07), so they go straight to where the work now lives.
+  { source: "/seeds", destination: "/#fields", permanent: true },
+  { source: "/action", destination: "/#fields", permanent: true },
   { source: "/germinating", destination: "/stories", permanent: true },
   { source: "/news", destination: "/stories", permanent: true },
   { source: "/journal", destination: "/stories", permanent: true },
@@ -38,54 +38,56 @@ const launchRedirects = [
   // Canonical slug renames, 2026-04-23.
   {
     source: "/projects/diagrama-spain",
-    destination: "/projects/diagrama",
+    destination: "/#fields",
     permanent: true,
   },
   {
     source: "/projects/bg-fit-mount-isa",
-    destination: "/projects/bg-fit",
+    destination: "/#fields",
     permanent: true,
   },
   {
     source: "/projects/smart-hcp-gp-uplift",
-    destination: "/projects/smart-hcp-uplift",
+    destination: "/#fields",
     permanent: true,
   },
   {
     source: "/projects/pakkinjalki-kari",
-    destination: "/projects/pakkimjalki-kari",
+    destination: "/#fields",
     permanent: true,
   },
   {
     source: "/projects/goods-on-country",
-    destination: "/goods",
+    destination: "/fields/goods",
     permanent: true,
   },
-  { source: "/goods-on-country", destination: "/goods", permanent: true },
+  { source: "/goods-on-country", destination: "/fields/goods", permanent: true },
   { source: "/projects/the-harvest", destination: "/harvest", permanent: true },
   {
     source: "/projects/empathy-ledger",
-    destination: "/empathy-ledger",
+    destination: "/fields/empathy",
     permanent: true,
   },
   {
     source: "/projects/justicehub",
-    destination: "/justicehub",
+    destination: "/fields/justice",
     permanent: true,
   },
-  { source: "/projects/goods", destination: "/goods", permanent: true },
+  { source: "/projects/goods", destination: "/fields/goods", permanent: true },
   {
     source: "/projects/black-cockatoo-valley",
-    destination: "/farm",
+    destination: "/about#history",
     permanent: true,
   },
 
-  // Editorial-site closure, 2026-07-23. The old public information architecture
-  // remains in the repository for source material, but visitors should only move
-  // through the Living Field routes. Keep admin, API, webhook, Confessions, art
-  // detail, Harvest detail and story-article routes intact.
-  { source: "/projects", destination: "/#fields", permanent: false },
-  { source: "/projects/:slug*", destination: "/#fields", permanent: false },
+  // Editorial-site closure, 2026-07-23, made permanent 2026-08-07. The Living
+  // Field is the information architecture; /projects and /events are not coming
+  // back. 308 rather than 307, because a temporary code tells a crawler to keep
+  // the old URL indexed and check again, which is no longer true. The old page
+  // code remains in the repository as source material. Keep admin, API, webhook,
+  // Confessions, art detail, Harvest detail and story-article routes intact.
+  { source: "/projects", destination: "/#fields", permanent: true },
+  { source: "/projects/:slug*", destination: "/#fields", permanent: true },
   { source: "/goods", destination: "/fields/goods", permanent: false },
   {
     source: "/empathy-ledger",
@@ -113,7 +115,7 @@ const launchRedirects = [
   { source: "/studio", destination: "/about", permanent: false },
   { source: "/impact", destination: "/stories", permanent: false },
   { source: "/partners", destination: "/contact", permanent: false },
-  { source: "/events", destination: "/harvest", permanent: false },
+  { source: "/events", destination: "/harvest", permanent: true },
   { source: "/media", destination: "/stories", permanent: false },
   // Route unification, 2026-08-07: editorial articles moved from /blog/[slug]
   // to /stories/[slug] so one slug space serves packets and articles. 308s,
@@ -126,11 +128,12 @@ const launchRedirects = [
 
   // Deleted or demoted entries redirect to parent context.
   //
-  // While the editorial-site closure holds, the /projects/:slug* rule above
-  // matches first and sends all of these to /#fields in one hop (redirects are
-  // first-match-wins). The destinations here record where each retired URL
-  // belongs if /projects and /events ever return; do not "flatten" them to
-  // /#fields, which would bake the temporary closure into permanent redirects.
+  // The /projects/:slug* rule above matches first and sends all of these to
+  // /#fields in one hop (redirects are first-match-wins), so they are dormant and
+  // the redirect check reports them as such. Their destinations were flattened on
+  // 2026-08-07: they used to point at /projects and /events, which are themselves
+  // closed, so each held URL would have cost two hops the moment it went live.
+  // The earlier warning against flattening assumed the closure was temporary.
   {
     source: "/projects/green-harvest-witta",
     destination: "/harvest",
@@ -138,48 +141,48 @@ const launchRedirects = [
   },
   {
     source: "/projects/project-her-self",
-    destination: "/projects",
+    destination: "/#fields",
     permanent: true,
   },
   {
     source: "/projects/act-monthly-dinners",
-    destination: "/events",
+    destination: "/harvest",
     permanent: true,
   },
   {
     source: "/projects/10x10-retreat",
-    destination: "/events",
+    destination: "/harvest",
     permanent: true,
   },
   {
     source: "/projects/westpac-summit-2025",
-    destination: "/events",
+    destination: "/harvest",
     permanent: true,
   },
   {
     source: "/projects/bupa-tfn-pitch",
-    destination: "/events",
+    destination: "/harvest",
     permanent: true,
   },
   {
     source: "/projects/naidoc-week-mount-isa",
-    destination: "/events",
+    destination: "/harvest",
     permanent: true,
   },
-  { source: "/projects/dad-lab-25", destination: "/events", permanent: true },
+  { source: "/projects/dad-lab-25", destination: "/harvest", permanent: true },
   {
     source: "/projects/anat-spectra-2025",
-    destination: "/events",
+    destination: "/harvest",
     permanent: true,
   },
   {
     source: "/projects/cars-and-microcontrollers",
-    destination: "/events",
+    destination: "/harvest",
     permanent: true,
   },
   {
     source: "/projects/global-laundry-alliance",
-    destination: "/events",
+    destination: "/harvest",
     permanent: true,
   },
 
@@ -208,42 +211,42 @@ const launchRedirects = [
   // homepage mosaic, and related-projects (see heldProjectSlugs in public-projects).
   {
     source: "/projects/act-infrastructure",
-    destination: "/projects",
+    destination: "/#fields",
     permanent: false,
   },
   {
     source: "/projects/custodian-first-economy",
-    destination: "/projects",
+    destination: "/#fields",
     permanent: false,
   },
   {
     source: "/projects/facilitation",
-    destination: "/projects",
+    destination: "/#fields",
     permanent: false,
   },
   {
     source: "/projects/grantscope",
-    destination: "/projects",
+    destination: "/#fields",
     permanent: false,
   },
   {
     source: "/projects/minderoo-pitch-package",
-    destination: "/projects",
+    destination: "/#fields",
     permanent: false,
   },
   {
     source: "/projects/three-circles",
-    destination: "/projects",
+    destination: "/#fields",
     permanent: false,
   },
   {
     source: "/projects/the-full-idea",
-    destination: "/projects",
+    destination: "/#fields",
     permanent: false,
   },
   {
     source: "/projects/annual-field-service",
-    destination: "/projects",
+    destination: "/#fields",
     permanent: false,
   },
 

--- a/docs/integrations/empathy-ledger/data-asks.md
+++ b/docs/integrations/empathy-ledger/data-asks.md
@@ -1,0 +1,64 @@
+# What the site needs from Empathy Ledger
+
+> Written 2026-08-07. Figures verified against
+> `src/data/empathy-ledger-editorial.generated.json` on that date, not carried
+> over from an earlier draft. Re-check them before sending if the sync has run
+> since.
+
+Five asks, and they are not equal. Two are holding the site back today. Three
+are quality and can follow.
+
+## The two that matter
+
+### 1. Real publish dates
+
+26 articles carry **5 distinct timestamps between them**. Eighteen share
+`2026-01-09T23:40:59.476+00:00` to the millisecond, which is a migration
+artifact rather than a publication date.
+
+The site does not print them. Field pages render no dates at all, because
+showing that timestamp would tell a reader something false about when the work
+happened. A guard test in `field-graph.test.ts` flips when real dates arrive.
+
+So the cost is not cosmetic. Twenty-six pieces of writing sit on the site with
+nothing to say when they were made, and a reader cannot tell what is current.
+
+**What we need:** the original publication date per article, or the best
+available date with a note on what it represents.
+
+### 2. One key for the corpus, not two
+
+The sync writes with `editorialDestination: "act_el"`. The runtime reads
+`/api/v2/sites/act-regenerative-studio/...`. Two identifiers for the same site.
+
+We cannot tell from this side whether they resolve to the same set of articles.
+If they ever diverge, the baked snapshot and the live read disagree and the site
+serves whichever it happened to get, with nothing to signal that anything is
+wrong. That is the kind of fault that stays quiet until someone notices an
+article missing.
+
+**What we need:** confirmation they select the same corpus, or one key that
+both paths should use.
+
+## The three that are quality
+
+| | State | What it costs |
+| --- | --- | --- |
+| **Featured image alt text** | 0 of the 18 articles with a featured image carry alt text | The site strips Webflow filename junk and falls back to the article title. Anyone using a screen reader gets the headline read twice |
+| **Media captions** | 0 of 123 media items carry a caption, and none carry alt text either | Photographs of people and places arrive with nothing said about them. Captions are where consent and context usually live |
+| **Per-article bylines** | All 26 attribute to Benjamin Knight | Person-voiced pieces are told by the people in them. The byline should say so |
+
+The bylines one matters more than its position here suggests. An article in
+someone's own voice, credited to someone else, is the thing Empathy Ledger
+exists to prevent.
+
+## What we are not asking for
+
+Not a schema change, and not a rebuild. Four of the five are fields that already
+exist and are empty. The fifth is a question about which key is authoritative.
+
+## If only one thing gets done
+
+The dates. Everything else degrades gracefully, and a reader can live without a
+caption. A body of work with no dates reads as abandoned, and the site currently
+chooses silence over stating something untrue.

--- a/docs/strategy/website-launch-cutover-plan.md
+++ b/docs/strategy/website-launch-cutover-plan.md
@@ -131,21 +131,30 @@ would arrive through the data rather than through the route.
 ## Empathy Ledger data asks
 
 These cap editorial quality on the site and are upstream fixes, not site work.
-Raised with the EL side; timeline unconfirmed.
+The sendable version, ranked rather than listed as five equal requests, is
+[docs/integrations/empathy-ledger/data-asks.md](../integrations/empathy-ledger/data-asks.md).
 
-- **Real publish dates.** 21 of 29 articles share one timestamp to the
-  millisecond. Field pages deliberately render no dates because printing the
-  migration artifact would state something false. Dates return to the pages
-  when the feed carries real ones (a guard test in `field-graph.test.ts`
-  flips when they arrive).
-- **Media captions.** 0 of 114 photos carry captions.
-- **Featured-image alt text.** 0 of 26 featured images carry alts; the site
-  strips Webflow filename junk and falls back to the article title.
-- **Per-article authors.** Every article currently attributes to one person;
-  person-voiced pieces need their real storyteller bylines.
-- **Destination-key alignment.** The sync uses the `act_el` destination key,
-  the live read filters by site slug; the two paths can return different
-  corpora. Needs one key.
+Figures re-verified against `empathy-ledger-editorial.generated.json` on
+2026-08-07. The earlier numbers here were stale, having been carried from a
+larger corpus, and are corrected below.
+
+- **Real publish dates.** 26 articles carry 5 distinct timestamps between them;
+  18 share `2026-01-09T23:40:59.476+00:00` to the millisecond. Field pages
+  deliberately render no dates, because printing that migration artifact would
+  state something false. A guard test in `field-graph.test.ts` flips when real
+  dates arrive.
+- **Destination-key alignment.** The sync writes `editorialDestination:
+  "act_el"`; the runtime reads `/api/v2/sites/act-regenerative-studio/`. Two
+  identifiers for one site, and nothing on this side can tell whether they
+  select the same corpus. If they diverge, the snapshot and the live read
+  disagree silently.
+- **Featured-image alt text.** 0 of the 18 articles that have a featured image
+  carry alt text; the site strips Webflow filename junk and falls back to the
+  article title.
+- **Media captions.** 0 of 123 media items carry a caption, and none carry alt
+  text either.
+- **Per-article authors.** All 26 attribute to one person; person-voiced pieces
+  need their real storyteller bylines.
 
 ## Ready to cut over
 

--- a/docs/strategy/website-launch-cutover-plan.md
+++ b/docs/strategy/website-launch-cutover-plan.md
@@ -111,8 +111,22 @@ with the hold.
 | --- | --- | --- |
 | `/storytellers` | Only one consented profile syndicates | More than one consented storyteller profile flows from Empathy Ledger |
 | `/ask` | Public AI Q&A unreviewed | Cost, safety and prompt-injection review done; rate limiting and moderation decided; explicit go |
-| `/wiki` | Sync leaked internal R&D and finance content | `sync-canonical-wiki-pages.mjs` glob exclusions fixed; finance/decisions visibility decided; article quality pass per the operating system's wiki standard |
+| `/wiki` | **Not a hold pending fixes any more. Decided 2026-08-07: the wiki is internal.** It stays in the repository and stays useful to us; it does not go out to the public | Only if that decision is reversed, and then the original blockers still apply: `sync-canonical-wiki-pages.mjs` glob exclusions fixed, finance and decisions visibility decided, article quality pass per the operating system's wiki standard |
 | `/people` | Internal research notes leaked into public bios | EL bio source sanitised; re-audit of every published bio before reversal |
+
+### The wiki stays internal
+
+Checked on production on 2026-08-07, because "held" and "not reachable" are not
+the same claim. `src/lib/projects/get-project-data.ts` reads the generated wiki
+data and is imported by live public routes (`/harvest`, `/empathy-ledger`,
+`/art/residencies`, `/farm/*`), so the internal material could have travelled
+without `/wiki` being reachable at all. It has not: a scan of those pages for
+revenue figures, funder scores, Xero invoice numbers and political contacts came
+back clean. The single hit is the `ACT-HV` project code on `/harvest`, carried as
+a form-tagging prop rather than shown as copy.
+
+Worth re-running that scan whenever the wiki sync regenerates, since the leak
+would arrive through the data rather than through the route.
 
 ## Empathy Ledger data asks
 

--- a/docs/strategy/website-launch-cutover-plan.md
+++ b/docs/strategy/website-launch-cutover-plan.md
@@ -114,6 +114,22 @@ with the hold.
 | `/wiki` | **Not a hold pending fixes any more. Decided 2026-08-07: the wiki is internal.** It stays in the repository and stays useful to us; it does not go out to the public | Only if that decision is reversed, and then the original blockers still apply: `sync-canonical-wiki-pages.mjs` glob exclusions fixed, finance and decisions visibility decided, article quality pass per the operating system's wiki standard |
 | `/people` | Internal research notes leaked into public bios | EL bio source sanitised; re-audit of every published bio before reversal |
 
+### This site does not sell. The destinations do.
+
+Decided 2026-08-07, closing a question raised by the route walk. Every path here
+ends at a contact form, and the essay asks for buyers who can place real orders
+because a promise of demand does not pay a wage. The answer is that ordering
+belongs on the destination sites, JusticeHub, Goods on Country, Empathy Ledger
+and The Harvest, not on the hub.
+
+That matches how the site is already built. Every field page hands off twice,
+sideways to another field and outward to the real thing, so the hub is a doorway
+rather than a shop. Worth writing down so it is not rediscovered as a gap: the
+absence is the design.
+
+The Harvest is the exception and stays one, because the place is the product:
+`/harvest/csa` takes members and `/harvest/produce` says what is in season.
+
 ### The wiki stays internal
 
 Checked on production on 2026-08-07, because "held" and "not reachable" are not

--- a/scripts/check-launch-redirects.mjs
+++ b/scripts/check-launch-redirects.mjs
@@ -50,10 +50,28 @@ function coveredBy(index) {
   return null;
 }
 
+// A rule whose destination is itself redirected costs the visitor a second hop and
+// splits the link equity across two URLs, and this check could not see it: it
+// asserts one hop at a time, so /projects/justicehub -> /justicehub passed while
+// the browser went on to /fields/justice. Thirty rules had drifted into chains
+// behind the editorial-site closure before anyone noticed.
+function chainedDestination(destination) {
+  const target = destination.split("#")[0];
+  const hit = launchRedirects.find((entry) => entry.source && matchers[launchRedirects.indexOf(entry)]?.test(target));
+  return hit && hit.destination !== destination ? hit.destination : null;
+}
+
 for (const [index, redirect] of launchRedirects.entries()) {
   if (!redirect.source || !redirect.destination) {
     failures.push(`redirect entry is missing source or destination: ${JSON.stringify(redirect)}`);
     continue;
+  }
+
+  const onward = chainedDestination(redirect.destination);
+  if (onward) {
+    failures.push(
+      `${redirect.source}: destination ${redirect.destination} redirects on to ${onward}; point it at the final page`,
+    );
   }
 
   const cover = coveredBy(index);

--- a/thoughts/shared/handoffs/website-launch-review/current.md
+++ b/thoughts/shared/handoffs/website-launch-review/current.md
@@ -1,0 +1,173 @@
+---
+date: 2026-08-07T09:40:00Z
+session_name: website-launch-review
+branch: launch-flatten-closure
+status: active
+---
+
+# Work Stream: website-launch-review
+
+## Ledger
+<!-- This section is extracted by SessionStart hook for quick resume -->
+**Updated:** 2026-08-07T09:40:00Z
+**Goal:** Get the site launch-ready so the cutover to act.place is a config change, not a scramble. Code side is DONE. What remains is DNS/env/third-party, which is Ben's.
+**Branch:** `launch-flatten-closure` (PR #62 open). `main` at `c500992`.
+**Test:** `npx tsc --noEmit && npm run test`. Gates need a running server: `LAUNCH_CHECK_BASE_URL=<url> node scripts/check-launch-site.mjs`, `REDIRECT_CHECK_BASE_URL=<url> node scripts/check-launch-redirects.mjs`, `CONTRAST_BASE_URL=<url> node scripts/check-contrast.mjs`. Dev on :3007 (:3001 is often The Harvest). **Restart the dev server after any change to `config/launch-redirects.cjs`** — next.config reads it at boot.
+
+### Now
+[->] SESSION CLEARED 2026-08-07 (second clear). State:
+- **`054f8d7` may be UNPUSHED** — check `git log origin/launch-flatten-closure..HEAD`. If so, push it; PR #62 is missing it.
+- **PR #62 open, MERGEABLE**, awaiting Ben's merge verb. PRs #60 and #61 merged and deployed and verified live earlier today.
+- **Ben's next move is the cutover itself** (his, not ours): point act.place DNS **with MX records recorded first, the one way this breaks his email**, set `NEXT_PUBLIC_SITE_URL=https://act.place` in Vercel Production, ship a build, repoint the EL webhook, sweep GHL, add Search Console. When he says the domain is pointed: re-run both gates against `https://act.place` and spot-check robots host, sitemap `<loc>` hosts, and a canonical on one static page plus one `/stories/[slug]`.
+- **EL brief is written and NOT committed** at `/Users/benknight/Code/empathy-ledger-v2/docs/08-integrations/ACT_SITE_EDITORIAL_DATA_BRIEF.md`. That repo had 67 uncommitted files on `feat/age-is-a-column-not-prose` and was being worked in, so it was deliberately left untracked. Do not commit there without checking with Ben.
+
+### Decisions taken 2026-08-07 (all recorded in docs/strategy/website-launch-cutover-plan.md)
+- **Domain: `act.place`.** The old ACT site's address; launch-redirects already maps its routes in, so cutover is replacement in place.
+- **`hi@act.place` stays.** No code change. It is in 11 source files, not the 5 the plan claimed.
+- **`www.act.place` to the apex.** Ordinary www-to-apex, not a legacy 301.
+- **`/projects` and `/events` closure is PERMANENT.** Living Field is the IA. Moved 307 to 308.
+- **The wiki is internal.** Stays in the repo, stays useful, never goes public. Not a hold pending fixes. Left redirected (Ben chose this over gating it behind ACT_INTERNAL_TOKEN).
+- **The hub does not sell.** Ordering belongs on JusticeHub, Goods, Empathy Ledger, The Harvest. The absence is the design. The Harvest is the exception because the place is the product.
+
+### Traps worth not rediscovering
+- **`public/media/field-videos/` is GITIGNORED.** `/media/field-videos/*` 308s to the Supabase `site-media` bucket (next.config.js), and that redirect runs BEFORE static file serving, so a file encoded locally is never what a browser fetches, even in dev. Encoding is not publishing. `scripts/build-hero-encodes.mjs --publish` uploads; it HEADs the bucket and only lists what it can actually serve.
+- **Hero encode filenames carry a content hash** because objects are served `immutable, max-age=31536000`. Replacing bytes at a fixed URL left a browser holding the old clip until 2027. This was caught live: the browser kept serving the square 1120x1078 encode while the bucket already had 1600x900.
+- **Verify pixels, not wiring.** Twice this session "working" was claimed off a `src` attribute while `readyState` was 0 and `videoWidth` 0. Assert readyState/videoWidth/currentTime. And **re-query the element after any await** — React remounts on key change and a stale ref reads as paused with a mismatched caption.
+- **Three gate holes closed this session, all the same shape: the check was measuring the wrong thing, not failing to run.** (1) the stale-reference scan judged the site's own host as foreign, would have failed all 28 routes at cutover; (2) the site gate followed redirects and validated the destination, so `/confessions/wall` passed while 307ing away; (3) the redirect gate asserted one hop while the browser kept travelling, hiding 30 chains.
+- **`white-space: nowrap` on the hero h1 was removed.** It overflowed instead of wrapping, which is how the old headline painted across the artwork, and left 0px slack at 320px.
+- **`main > section` is clamped to 1200px in globals.css**; the opt-out is `max-width:none; margin-inline:0`. Any new full-width band needs it or it floats.
+
+### This Session (2026-08-07, Phases 1-2)
+- [x] Phase 1 page-by-page review with Ben → PR #57 (branch launch-review-fixes: corpus commit 97ac9b7 + batch 1-3 fixes 953df80). All CI green, MERGEABLE, awaiting Ben's merge verb.
+- [x] Phase 2 route decisions made with Ben and implemented in 716e5c6 on launch-routes-unify (stacked on launch-review-fixes, UNPUSHED):
+  - Articles unified under /stories/[slug] (packets resolve first, articles second; /blog + /blog/:slug* are 308s; /blog directory deleted; localPath normalised at serving boundary + sync script)
+  - Live chains flattened: /news, /journal → /stories; /lcaa → /about#convictions; /ask → /questions; /wiki, /wiki/new → /#fields
+  - Event-demotion + deleted-project rules left alone ON PURPOSE: /projects/:slug* catch-all matches first, they are inert today and correct if the closure reverses (comments in config say so)
+  - All four holds stay held for launch (criteria go into the Phase 3 plan)
+  - Sitemap: + /confessions/wall + /confessions/method + published packets (none yet: utopia is public-preview/noindex); articles at /stories/
+  - Launch gate: + /stories/the-spirit-must-be-strong sample; off-site (EL) canonicals skip path-equality, site host read from homepage canonical
+- [x] Verified on local prod build: one-hop redirects, both content types render, 404 on unknown, 21 /stories/ sitemap articles, zero /blog/; tsc clean, 22 tests, gate passes 28 routes
+
+### Earlier (2026-08-06 session)
+- [x] Three-agent audit; P0 consent gates; P1 /blog/[slug] renderer rebuild; EL fetch deploy-killer fixed; PRs #55 + #56 shipped + prod verified
+
+### Phase 1 landed (2026-08-07)
+- [x] PR #57 MERGED as b6fcdc2, deployed, verified live: home API silence, legal footer, letterboxing, 3 withdrawn slugs 404, showcase article intact
+
+### Phase 2 in flight
+- [x] launch-routes-unify rebased onto main (single commit 1bcc22f), pushed, PR #58 open; CI: lint/type/security/preview green, Build + Tests pending at handoff-write time
+
+### Phase 3 done (2026-08-07)
+- [x] docs/strategy/website-launch-cutover-plan.md written + OS doc reconciled (pointer + /stories decision recorded); committed LOCALLY as c9c5360 on launch-routes-unify, NOT pushed (pushing adds it to PR #58 — Ben's call)
+- Plan's open inputs for Ben: which domain; keep or move hi@act.place; www.act.place legacy redirect
+
+### Session 2026-08-07b (cutover decisions + gate repair)
+- [x] Domain decided: **act.place** — the address the old ACT site occupies, whose routes launch-redirects.cjs already maps in. Cutover is a replacement in place.
+- [x] Email decided: **hi@act.place stays**, no code change (it is in 11 source files, not the 5 the plan claimed)
+- [x] Third decision self-resolved: www.act.place is now an ordinary www→apex redirect, not a legacy 301
+- [x] **Two launch gates would have failed the cutover. Both fixed** in `15e0784` on branch `launch-cutover-decisions` (off main, UNPUSHED):
+  - `check-launch-site.mjs` treated `https://act.place` as a stale link to the old site. Canonical + og:url emit the site host on every page and only script/style are stripped, so head survives the scan (verified on live prod markup: 4 hits/page). All 28 routes would have failed at cutover. Now strips the site's own origin first; other-form-of-domain links still fail; host patterns got a boundary so act.placeholder.com cannot trip them.
+  - `check-launch-redirects.mjs` was **already red against prod** (30 assertions), unnoticed because the gate is not in CI. All 19 rules are retired /projects/* entries covered by the /projects/:slug* closure. Redirects are first-match-wins; the checker had no precedence notion so it tested the closure, not the rules. Now resolves coverage in declaration order and reports dormant.
+- [x] Verified on prod: site gate 28 routes green; redirect gate 75 checked / 19 dormant / green; PR #58 route unification live (/stories/[slug] 200, /blog + /blog/[slug] + /news one-hop 308); tsc clean; 22 tests
+- [x] Cutover plan updated: decisions section, act.place substituted throughout, steps 6-7 rewritten, ready-to-cut-over checklist ticked with evidence + dates
+
+### Session 2026-08-07c (homepage design pass, branch `launch-cutover-decisions`)
+- [x] `c687564` full-bleed bands + hero: globals.css clamps `main > section` to 1200px; the method ribbon escaped only because it is an `<aside>`. `.harvest`/`.return` already had the escape, `.fieldSection`/`.crossStory`/`.hero` never did. The hero was the bad one: headline column 405px vs 537px needed for "system felt." (nowrap), so type painted 54px across the artwork.
+- [x] `4f29f1e` hero rotates the fields + return mark off the photo. **Lesson: the first mark fix used a fixed offset above the photo — cleared at 1920x1080 but hit the header by 32px at 1440x760 and 19px at 1440x900, because the photo's y position moves with viewport height. Now in normal flow so the column reserves its space; collision is structurally impossible.**
+- [x] `24f6d3d` "the field speaks": each field's own line (from living-field.ts) over its own footage; 5 seeds = clickable nav, 44px targets, hold-on-hover/focus; return mark redraws per change; h1 stays fixed for SEO/SR; aria-live off; reduced-motion honoured
+- [x] `dd8874a` hero encodes published to Supabase `site-media`. **Trap worth remembering: `public/media/field-videos/` is GITIGNORED and `/media/field-videos/*` 308s to the bucket (next.config.js), and that redirect runs BEFORE static file serving — so a file encoded locally is never the file the browser fetches, even in dev.** Script HEADs the bucket and only lists encodes it can actually serve; `--publish` uploads with POST (creates, never overwrites).
+- Weight: six clips 34,274KB → 3,421KB; **first paint 9,956KB → 59KB** (rotation opens on Art). Verified through the real 308→bucket path, all 200.
+- **Process lesson: I twice claimed "working" from wiring rather than pixels.** `src` attribute set ≠ video loaded (`readyState 0`, `videoWidth 0`). Always assert readyState/videoWidth/currentTime, and re-query the element after any await (React remounts on key change; a stale ref reads as paused + mismatched).
+- Still open: `harvest-field-notes-dji-0021-hero.mp4` is 1591KB, 3-5x the others (drone aerial, high motion). 6x better than before but worth a higher CRF or a calmer clip.
+
+### Next
+- [ ] Push `054f8d7` if unpushed, then Ben merges PR #62
+- [ ] Ben: the cutover (DNS + MX first, env, build, EL webhook, GHL sweep, Search Console)
+- [ ] On Ben's word that act.place is pointed: re-run both gates against it, spot-check robots/sitemap/canonicals
+- [ ] Ben: send the EL brief (path above). `/storytellers` and `/people` unblock behind it; `/ask` needs a safety review he would commission
+- [ ] Optional follow-ups, both flagged and deliberately not done: delete the 19 dormant `/projects/*` rules now the closure is permanent; remove the `/projects` and `/events` page code (needs an import check first)
+
+### Decisions
+- Prod on act-regenerative-studio.vercel.app is **staging-in-place**; real launch = cutover to a new domain (Ben, 2026-08-06)
+- One renderer: /blog/[slug] carries the editorial design; StoryScroll remains for authored story packets
+- EL failures never take the site down — null → baked snapshot, always
+- DGR/entity/brand rules per CLAUDE.md apply to all public copy reviewed in this stream
+
+### Open Questions
+- RESOLVED 2026-08-07: domain is act.place; hi@act.place stays; www→apex
+- UNCONFIRMED: DNS access for act.place, and whether its current MX records are recorded before the nameserver/A-record change (the one way this cutover breaks email)
+- UNCONFIRMED: whether any external caller (cron, other repo) hits the newly-gated knowledge/registry endpoints anonymously
+- UNCONFIRMED: EL-side appetite/timeline for data fixes (real publish dates, captions, per-article authors, featured-image alts)
+
+### Workflow State
+pattern: review-then-plan
+phase: 1
+total_phases: 3
+retries: 0
+max_retries: 3
+
+#### Resolved
+- goal: "walk through full page review and routes, then align the launch plan"
+- resource_allocation: balanced
+
+#### Unknowns
+- new_domain: UNKNOWN
+- el_data_fix_timeline: UNKNOWN
+
+#### Last Failure
+(none — both prod deploy failures root-caused and fixed in #56)
+
+---
+
+## Context
+
+### Kickoff prompt for next session (paste or run as-is)
+
+> Walk me through the full launch review in three phases. Work from
+> `thoughts/shared/handoffs/website-launch-review/current.md` and memory
+> `project_editorial_p1_state`.
+>
+> **Phase 1 — page-by-page review.** Take the live route inventory (24 sitemap
+> routes + /stories/[slug] + /blog/[slug] articles) and walk me through them a
+> section at a time on production, in this order: home, /about, /contact,
+> /fields/* (5), /stories + 3–4 representative articles, /questions, /art + its
+> 5 subpages + a detail page, /harvest + csa/produce, /confessions cluster,
+> /privacy + /terms. For each: screenshot, judge copy against the ACT voice
+> rules (no em-dashes, Indigenous place names first, no bare LCAA/ALMA), check
+> data freshness (dates, stats, images), flag anything unfinished. Batch your
+> findings per section and give me accept/fix calls to make. Fix Tier-1 items
+> as we agree them; queue the rest.
+>
+> **Phase 2 — routes alignment.** Then put the route decisions to me one at a
+> time with a recommendation: (a) /blog vs /stories naming — articles live at
+> /blog/[slug] but the index is /stories and /blog 307s away; sitemap indexes
+> /blog/* but not /stories/[slug]; (b) the redirect chains through retired
+> routes (/wiki→/projects→/#fields, /lcaa→/method [308 into a dead hop],
+> /wiki/new→/wiki, /ask→/projects); (c) the four launch holds (/storytellers,
+> /ask, /wiki, /people) — confirm each stays held for launch and record the
+> un-block criteria; (d) sitemap gaps (/stories/[slug] absent,
+> /confessions/method absent) and the check-launch-site.mjs launchRoutes drift.
+> Apply what we decide in config/launch-redirects.cjs + sitemap.ts +
+> check-launch-site.mjs together (the file's own comment demands all three
+> move in lockstep).
+>
+> **Phase 3 — align the launch plan.** Write the launch plan as a short doc:
+> new-domain cutover checklist (Vercel domain, NEXT_PUBLIC_SITE_URL at build
+> time, sitemap/robots host, GHL form source fields, EL webhook destination
+> URLs), the hold un-block criteria from Phase 2, the EL-side data asks (real
+> publish dates, captions, per-article authors, featured-image alts — these cap
+> editorial quality and are upstream fixes), and what "ready to cut over" means
+> as a checklist we can tick. Reconcile it against
+> docs/strategy/website-launch-operating-system.md rather than duplicating it.
+>
+> Pause for my call at each phase boundary. Don't push or merge anything
+> without my explicit verb.
+
+### State that matters (verified this session)
+
+- **Shipped + live:** a11ed96 (#55 editorial + consent/auth) and 72d27dc (#56 EL runtime hardening); verified on `/blog/the-spirit-must-be-strong` (full-bleed figures), `/blog/powering-change-a-curious-tractors-journey` (typographic hero), `/blog/historys-wounds-and-tomorrows-possibilities` (Descript embeds). Zero junk alts, zero "no public body" placeholders.
+- **The deploy trap (do not reintroduce):** never pass an AbortSignal to an EL fetch — Next's background cache-write rejects outside try/catch and kills the build. `performEmpathyLedgerFetch` races an un-signalled fetch vs a timer and abandons on timeout.
+- **Working tree:** 9 regenerated `src/data/*.generated.json` uncommitted on purpose. The regen drops 3 articles (vireak, nhat, +1); `field-assignments.ts` has 3 stale curated entries that must be fixed in the same commit (field-graph test enforces).
+- **Local main:** carries unpushed `f434188` (newsletter authoring scaffold) — ship separately.
+- **Route audit facts:** 94 pages; public site ungated; only /admin + /prototypes behind ACT_INTERNAL_TOKEN (404-on-deny); holds at config/launch-redirects.cjs:169-183 with rationale comments; the four top public pages import their bodies from src/app/prototypes/* (works, but fragile).
+- **P2 backlog detail** lives in memory `project_editorial_p1_state` — destination-key divergence (act_el vs site slug), live read unpaginated (limit=100), per-process unavailable latch never resets, HOME_CURATED_SLUGS hardcoded.


### PR DESCRIPTION
Three decisions taken with Ben on 2026-08-07, implemented, plus the defect the
first one exposed.

## The closure is permanent, and it was costing two hops

Decided: the Living Field is the information architecture; `/projects` and
`/events` are not coming back. Both move from 307 to 308, because a temporary
code tells a crawler to keep the old URL indexed and check again, which is no
longer true.

Going in to flatten the 19 dormant rules turned up **30 rules whose destination
was itself a redirect**, and not only retired ones:

| | was | now |
| --- | --- | --- |
| `/projects/justicehub` | `/justicehub` then `/fields/justice` | one hop |
| `/seeds` | `/projects` then `/#fields` | one hop |
| `/projects/goods-on-country` | `/goods` then `/fields/goods` | one hop |
| `/projects/diagrama-spain` | `/projects/diagrama` then `/#fields` | one hop |

Every canonical slug rename landed on a slug that was itself closed. Two-hop
behaviour verified on production before anything changed, then all thirty
flattened to their final destination.

**The gate could not see it.** `check-launch-redirects.mjs` asserts one hop at a
time, so each of those rules passed while the browser kept travelling. It now
walks each destination through the map and fails a rule whose destination
redirects again. Third gate hole closed this week, and the same shape each time:
the check was measuring the wrong thing rather than failing to run.

The config's warning against flattening these is discharged rather than ignored.
It existed because the closure was temporary, and said so; the comments are
rewritten so the file no longer describes a state that is not true.

## The wiki is internal by decision

Decided: it stays in the repository and stays useful to us, and does not go out
to the public. The holds table described it as waiting on a sync fix, a
visibility call and a quality pass, which read as queued work rather than a
decision taken.

Checked what "held" actually buys, because held and unreachable are different
claims. `get-project-data.ts` reads the generated wiki data and is imported by
live public routes (`/harvest`, `/empathy-ledger`, `/art/residencies`,
`/farm/*`), so internal material could travel without `/wiki` being reachable at
all. Scanned those pages on production for revenue figures, funder scores, Xero
invoice numbers and political contacts: clean. One hit, the `ACT-HV` project code
on `/harvest`, carried as a form-tagging prop rather than shown as copy. That
scan is worth repeating whenever the sync regenerates, since a leak would arrive
through the data rather than the route.

## The Empathy Ledger asks, ranked and re-verified

The plan listed five requests as if they weighed the same. Now ranked, with a
sendable version at `docs/integrations/empathy-ledger/data-asks.md`.

Every figure was re-verified against the generated editorial data instead of
being carried over, and every one was wrong: 26 articles not 29, five distinct
timestamps with 18 sharing one to the millisecond rather than 21 of 29, 123
uncaptioned media items not 114 photos, and 18 articles carrying a featured
image with none carrying alt text where the plan claimed 26 images.

The destination key is promoted out of the quality list: the sync writes
`editorialDestination: "act_el"` while the runtime reads
`/api/v2/sites/act-regenerative-studio/`, and nothing on this side can tell
whether two identifiers select the same corpus. If they diverge, the snapshot and
the live read disagree with nothing to signal it.

## Method note

This is the **Listen** step arriving after the prototype, not before it. The
route walk that produced these came after the build, and **Curiosity** about one
dormant rule is what turned up thirty live chains. Action and Art did not wait
their turn either. The homepage ribbon now says as much.

## Checklist

- [x] `npx tsc --noEmit` clean
- [x] 22 tests passing
- [x] Redirect gate green, 75 rules with 19 dormant, after restarting so `next.config` reloads the map
- [x] Site gate green, 27 routes
- [x] Ten representative paths verified resolving in exactly one hop
- [x] Zero stale "temporary closure" comments left in the config
- [x] EL figures verified against the data, not the previous draft
- [ ] Post-merge: re-run both gates against production and confirm the one-hop resolution survives the deploy

## Not in this PR

The `/projects` and `/events` page code is still in the repository. Removing it
is a separate call, and needs a check that nothing else imports from those
directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
