### PR TITLE
Story layer: 107 dead photographs, two false claims, and hero text that was measured

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "check:copy": "node scripts/check-public-copy.mjs",
     "check:copy:data": "node scripts/check-public-copy.mjs --data",
     "check:forms": "node scripts/check-form-payloads.mjs",
+    "check:media": "node scripts/check-editorial-media.mjs",
+    "check:media:report": "node scripts/check-editorial-media.mjs --report",
     "check:launch": "node scripts/check-launch-site.mjs",
     "check:launch-ready": "node scripts/check-launch-ready.mjs",
     "check:launch-ready:build": "node scripts/check-launch-ready.mjs --with-build",

--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -51,6 +51,30 @@ const routes = [
 ];
 
 /**
+ * One story article, resolved at run time rather than hard-coded.
+ *
+ * /stories/[slug] was never in this list, so the reading experience, which is
+ * the longest page on the site and the only one that lays text over an
+ * arbitrary photograph, went unchecked. Article slugs come from Empathy Ledger
+ * and change without notice, so naming one here would make the gate fail on an
+ * upstream edit rather than on a real regression.
+ *
+ * Text over the hero photograph is still skipped by the collector, as all
+ * text over media is; it cannot be judged from computed style. That part is
+ * measured by sampling rendered pixels instead, which is how the clay-gold
+ * "All stories" link was found failing at 1.58:1 and moved off the photograph.
+ */
+async function resolveStoryRoute(page) {
+  const response = await page.goto(`${baseUrl}/stories`, { waitUntil: "load", timeout: 60_000 });
+  if (!response || response.status() !== 200) return null;
+  const slug = await page.evaluate(() => {
+    const link = document.querySelector('a[href^="/stories/"]');
+    return link ? link.getAttribute("href") : null;
+  });
+  return slug;
+}
+
+/**
  * Runs inside the page. Walks every leaf text node, resolves the nearest
  * opaque ancestor background, and applies the WCAG 2.1 contrast formula.
  *
@@ -168,6 +192,10 @@ async function main() {
   const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
   const all = [];
   let totalSkipped = 0;
+
+  const storyRoute = await resolveStoryRoute(page);
+  if (storyRoute) routes.push(storyRoute);
+  else console.log("  note: no story article found to check; /stories may be empty");
 
   for (const route of routes) {
     // "load", not "networkidle": the dev server holds an HMR websocket open,

--- a/scripts/check-editorial-media.mjs
+++ b/scripts/check-editorial-media.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Probes every photograph a story page actually renders, and reports the dead.
+ *
+ * Written 2026-08-07, after production was found serving 107 dead images
+ * across 18 of its 21 story pages. What a reader met was a broken frame every
+ * few paragraphs, and eighteen of them in "At the Speed of Ceremony".
+ *
+ * The cause is upstream and specific. Empathy Ledger has moved its media to
+ * `empathyledger.com/api/media/<id>/file`, and the structured fields of the
+ * feed carry the new URLs: hero images and gallery photographs resolve. The
+ * exported article HTML was not rewritten in that move, so every photograph
+ * embedded in the prose still points at the retired Supabase bucket and
+ * returns 400. Empathy Ledger's own article pages show the same damage, which
+ * is how we know it is not this site's configuration.
+ *
+ * This checks rendered pages rather than the committed snapshot, deliberately.
+ * The snapshot in src/data is a build-time fallback that goes stale between
+ * syncs, and measuring it produced a picture that disagreed with production in
+ * both directions: dead heroes that production renders fine, live galleries
+ * that it does not use. The page is the only honest subject.
+ *
+ * The renderers now hide photographs that fail, so none of this is visible to
+ * a reader any more. That makes the check more important rather than less:
+ * silent self-healing is exactly the condition under which a feed can rot to
+ * nothing while every page still looks well.
+ *
+ * Usage:
+ *   node scripts/check-editorial-media.mjs                      # against production
+ *   node scripts/check-editorial-media.mjs --base http://localhost:3001
+ *   node scripts/check-editorial-media.mjs --report             # full detail, never fails
+ */
+
+const DEFAULT_BASE = "https://act-regenerative-studio.vercel.app";
+
+/**
+ * Dead images measured on production, 2026-08-07: 107 across 21 story pages.
+ * The baseline exists so this fails on *new* rot rather than on damage already
+ * known and raised with Empathy Ledger. Lower it as photographs are restored;
+ * never raise it without saying why in the commit message.
+ */
+const DEAD_BASELINE = 107;
+
+const args = process.argv.slice(2);
+const reportOnly = args.includes("--report");
+const baseIndex = args.indexOf("--base");
+const BASE = (baseIndex >= 0 ? args[baseIndex + 1] : process.env.MEDIA_CHECK_BASE_URL) || DEFAULT_BASE;
+
+/** Pull every image URL a page renders, unwrapping Next's optimiser. */
+function imageUrls(html) {
+  const urls = new Set();
+  for (const attr of html.matchAll(/(?:src|srcSet|srcset)="([^"]+)"/g)) {
+    for (const candidate of attr[1].split(",")) {
+      let raw = candidate.trim().split(/\s+/)[0].replace(/&amp;/g, "&");
+      if (raw.startsWith("/_next/image")) {
+        raw = decodeURIComponent(new URL(raw, BASE).searchParams.get("url") || "");
+      }
+      if (!/^https?:\/\//.test(raw)) continue;
+      if (/\.(jpe?g|png|webp|gif|avif)(\?|#|$)/i.test(raw) || /\/api\/media\//.test(raw)) {
+        urls.add(raw);
+      }
+    }
+  }
+  return [...urls];
+}
+
+/**
+ * A 200 is not enough. The retired bucket answers a missing object with a JSON
+ * error body, so the content type is what distinguishes a photograph from a
+ * polite refusal. HEAD is not supported there and returns 400 for everything,
+ * which is how an earlier version of this measurement went wrong.
+ *
+ * A thrown fetch is a transport failure, not an answer. Probing hundreds of
+ * URLs produces one or two per run, and counting those as dead made the check
+ * fail at random and made a real regression indistinguishable from a dropped
+ * packet. A refusal that survives three attempts is treated as real.
+ */
+async function probe(url, attempt = 0) {
+  try {
+    const response = await fetch(url);
+    const contentType = response.headers.get("content-type") || "";
+    await response.arrayBuffer();
+    return { url, status: response.status, live: response.ok && contentType.startsWith("image/") };
+  } catch (error) {
+    if (attempt < 2) {
+      await new Promise((resolve) => setTimeout(resolve, 400 * (attempt + 1)));
+      return probe(url, attempt + 1);
+    }
+    return { url, status: 0, live: false, error: String(error).slice(0, 120) };
+  }
+}
+
+async function main() {
+  const index = await fetch(`${BASE}/stories`);
+  if (!index.ok) {
+    console.error(`Cannot read ${BASE}/stories (HTTP ${index.status}). Is the server up?`);
+    process.exit(1);
+  }
+  const slugs = [
+    ...new Set([...(await index.text()).matchAll(/href="\/stories\/([a-z0-9-]+)"/g)].map((m) => m[1])),
+  ];
+  if (slugs.length === 0) {
+    console.error("No story links found on the index. The page shape has changed.");
+    process.exit(1);
+  }
+
+  console.log(`Checking ${slugs.length} story pages at ${BASE}`);
+  const pages = [];
+
+  for (const slug of slugs) {
+    const response = await fetch(`${BASE}/stories/${slug}`);
+    const urls = response.ok ? imageUrls(await response.text()) : [];
+    const checked = [];
+    for (let i = 0; i < urls.length; i += 10) {
+      checked.push(...(await Promise.all(urls.slice(i, i + 10).map((url) => probe(url)))));
+    }
+    const dead = checked.filter((result) => !result.live);
+    pages.push({ slug, total: checked.length, dead });
+    if (reportOnly || dead.length) {
+      console.log(`  ${String(checked.length - dead.length).padStart(3)} live / ${String(dead.length).padStart(3)} dead   ${slug}`);
+    }
+  }
+
+  const totalImages = pages.reduce((count, page) => count + page.total, 0);
+  const totalDead = pages.reduce((count, page) => count + page.dead.length, 0);
+  const affected = pages.filter((page) => page.dead.length > 0).length;
+
+  console.log(`\n${totalImages - totalDead} live / ${totalDead} dead across ${pages.length} story pages (baseline ${DEAD_BASELINE})`);
+  console.log(`Pages with at least one dead photograph: ${affected}`);
+
+  if (reportOnly) {
+    const hosts = {};
+    for (const page of pages) {
+      for (const result of page.dead) {
+        const host = new URL(result.url).host;
+        hosts[host] = (hosts[host] || 0) + 1;
+      }
+    }
+    console.log("Dead by host:", JSON.stringify(hosts, null, 1));
+    return;
+  }
+
+  if (totalDead > DEAD_BASELINE) {
+    console.error(
+      `\nFAIL\n  dead photographs grew from ${DEAD_BASELINE} to ${totalDead}; the feed is still rotting`,
+    );
+    process.exit(1);
+  }
+  console.log("\nOK (no new losses since the recorded baseline)");
+}
+
+main().catch((error) => {
+  console.error("check-editorial-media failed to run:", error);
+  process.exit(1);
+});

--- a/src/app/prototypes/stories/page.tsx
+++ b/src/app/prototypes/stories/page.tsx
@@ -42,15 +42,27 @@ export async function StoriesExperience({
       <main>
         <section id="stories-introduction" className={styles.hero}>
           <p className={styles.eyebrow}>Stories across the field</p>
+          {/* "One place. Many voices." was not true. Every article in the feed
+              carries one byline, Benjamin Knight, and the line beneath it
+              claimed each story stays connected to "its people and its
+              permissions" when the feed carries no per-story consent record at
+              all. Both are the kind of claim ACT asks funders not to make.
+              Corrected 2026-08-07; the authorship note now sits in the
+              publishing-model section below, where it can be said plainly. */}
+          {/* Two short lines, because the display face is set at up to 10rem
+              and anything longer wraps to four and swallows the viewport.
+              "Field notes" was the first attempt and collided with the nav
+              item of that name, which points at /questions. */}
           <h1>
-            One place.
+            The writing
             <br />
-            Many voices.
+            so far.
           </h1>
           <div>
             <p>
-              Writing, images and films from across ACT's projects. Each story
-              stays connected to its source, its people and its permissions.
+              Writing from A Curious Tractor's work across justice, story,
+              making and place. Empathy Ledger holds the master copy of every
+              piece, so a story can be corrected or withdrawn at its source.
             </p>
             <dl>
               <div>
@@ -91,6 +103,13 @@ export async function StoriesExperience({
               If permission changes, the story can be withdrawn from every
               connected destination. The source remains visible, and each
               project can keep its own voice.
+            </p>
+            <p>
+              Every piece here is currently written by one of us, Benjamin
+              Knight. The work it describes belongs to the people and
+              organisations carrying it. That the writing has not caught up with
+              that yet is a fact about this page, not about the work, and the
+              next pieces should not come from us.
             </p>
             <a
               href="https://empathyledger.com"

--- a/src/app/prototypes/stories/stories-stream.tsx
+++ b/src/app/prototypes/stories/stories-stream.tsx
@@ -10,14 +10,21 @@ const publicText = (value: string) => value.replace(/[—–]/g, ",");
 
 export function StoriesStream({ stories }: { stories: EditorialArticle[] }) {
   const [project, setProject] = useState("all");
+  // Every featured image resolves today, but 81 of the 114 gallery photographs
+  // behind these same articles return HTTP 400 from Empathy Ledger's storage
+  // (measured 2026-08-07). A card whose image dies should fall back to the tile
+  // this grid already has for an article with no image, rather than leaving a
+  // browser's broken-image glyph in an editorial grid.
+  const [deadImages, setDeadImages] = useState<string[]>([]);
   const projects = useMemo(() => Array.from(new Set(stories.flatMap((story) => story.relatedProjectSlugs))).sort(), [stories]);
   const visible = project === "all" ? stories : stories.filter((story) => story.relatedProjectSlugs.includes(project));
   return <section className={styles.stream} aria-labelledby="stories-stream-title">
     <div className={styles.streamHead}><div><p className={styles.eyebrow}>The living stream</p><h2 id="stories-stream-title">Follow what is moving.</h2></div><div className={styles.filters} aria-label="Filter stories by project"><button type="button" aria-pressed={project === "all"} onClick={() => setProject("all")}>All</button>{projects.map((slug) => <button type="button" key={slug} aria-pressed={project === slug} onClick={() => setProject(slug)}>{projectNames[slug] || slug.replaceAll("-", " ")}</button>)}</div></div>
     <div className={styles.grid}>{visible.map((story, index) => {
       const video = story.media?.videoPreviews?.[0];
+      const image = story.featuredImageUrl && !deadImages.includes(story.featuredImageUrl) ? story.featuredImageUrl : null;
       return <article key={story.id} className={index === 0 && project === "all" ? styles.lead : ""}><Link href={story.localPath}>
-        <div className={styles.media}>{video?.url ? <video muted loop playsInline preload="metadata" poster={video.thumbnailUrl || story.featuredImageUrl || undefined} onMouseEnter={(event) => { void event.currentTarget.play().catch((error: unknown) => { if (!(error instanceof DOMException && error.name === "AbortError")) console.error("Story preview could not play", error); }); }} onMouseLeave={(event) => { event.currentTarget.pause(); event.currentTarget.currentTime = 0; }}><source src={video.url} /></video> : story.featuredImageUrl ? <img src={story.featuredImageUrl} alt={story.featuredImageAlt || ""} /> : <span>Story<br />waiting for an image</span>}{video?.url ? <b>Film</b> : null}</div>
+        <div className={styles.media}>{video?.url ? <video muted loop playsInline preload="metadata" poster={video.thumbnailUrl || image || undefined} onMouseEnter={(event) => { void event.currentTarget.play().catch((error: unknown) => { if (!(error instanceof DOMException && error.name === "AbortError")) console.error("Story preview could not play", error); }); }} onMouseLeave={(event) => { event.currentTarget.pause(); event.currentTarget.currentTime = 0; }}><source src={video.url} /></video> : image ? <img src={image} alt={story.featuredImageAlt || ""} onError={() => setDeadImages((current) => current.includes(image) ? current : [...current, image])} /> : <span>Story<br />waiting for an image</span>}{video?.url ? <b>Film</b> : null}</div>
         <div className={styles.copy}><p>{story.relatedProjectSlugs.map((slug) => projectNames[slug] || slug.replaceAll("-", " ")).join(" · ") || "Across ACT"}</p><h3>{publicText(story.title)}</h3>{story.excerpt ? <span>{publicText(story.excerpt)}</span> : null}<footer><em>{publicText(story.authorName || "A Curious Tractor")}</em><b>Read →</b></footer></div>
       </Link></article>;
     })}</div>

--- a/src/app/stories/[slug]/editorial-article.tsx
+++ b/src/app/stories/[slug]/editorial-article.tsx
@@ -179,13 +179,16 @@ export async function EditorialArticleReader({
           initial={post.title.charAt(0)}
         />
         <div className="relative z-10 mx-auto flex min-h-[60vh] max-w-[1000px] flex-col justify-end px-6 pb-16 pt-32 md:min-h-[75vh] md:px-10 md:pb-24 md:pt-40">
-          <Link
-            href="/stories"
-            className="inline-flex items-center gap-2 font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.3em] text-[#CFA16B] transition-all hover:gap-3 hover:text-[#E0B680]"
-          >
-            <span aria-hidden="true">&larr;</span> All stories
-          </Link>
-          <h1 className="mt-6 font-[var(--font-display)] text-[clamp(2.2rem,5vw,4.2rem)] font-light leading-[1.08] text-[#F3EBDD]">
+          {/* The "All stories" link used to sit here, above the title. It was
+              the topmost text in the hero and so the least covered by the
+              scrim, and it measured 1.58 to 4.18 against a photograph where
+              small text needs 4.5 (five heroes sampled by rendered pixel,
+              2026-08-07). No scrim opacity fixes it: the label is clay-gold,
+              a mid tone, so it needs a backdrop near solid black to clear AA,
+              and that is a slab over the photograph rather than a scrim.
+              It now sits below the hero on a solid surface, where the contrast
+              is deterministic and the existing gate can actually see it. */}
+          <h1 className="font-[var(--font-display)] text-[clamp(2.2rem,5vw,4.2rem)] font-light leading-[1.08] text-[#F3EBDD]">
             {post.title}
           </h1>
           {lede ? (
@@ -210,6 +213,21 @@ export async function EditorialArticleReader({
           </div>
         </div>
       </section>
+
+      {/* Return path, on the body's solid surface rather than over the
+          photograph. Forest green on #FBF6EC, the pairing the rest of the site
+          uses for links, rather than the clay-gold that only worked on dark. */}
+      <nav
+        aria-label="Breadcrumb"
+        className="border-b border-[var(--we-sand)] bg-[#FBF6EC] px-6 pt-8 md:px-10"
+      >
+        <Link
+          href="/stories"
+          className="mx-auto flex max-w-[720px] items-center gap-2 pb-8 font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.3em] text-forest transition-all hover:gap-3"
+        >
+          <span aria-hidden="true">&larr;</span> All stories
+        </Link>
+      </nav>
 
       {/* BODY: long-form article in a readable measure */}
       <section className="bg-[#FBF6EC] px-6 py-20 md:px-10 md:py-28">

--- a/src/app/stories/[slug]/editorial-article.tsx
+++ b/src/app/stories/[slug]/editorial-article.tsx
@@ -15,6 +15,9 @@ import {
   readingTimeMinutes,
 } from "@/lib/editorial/article-html";
 import { ReadingProgress } from "@/components/editorial/ReadingProgress";
+import { ArticleGallery } from "@/components/editorial/ArticleGallery";
+import { RichTextMedia } from "@/components/editorial/RichTextMedia";
+import { ArticleHeroMedia } from "@/components/editorial/ArticleHeroMedia";
 import {
   fieldsForArticle,
   projectSlugDestination,
@@ -59,17 +62,21 @@ function shortLede(raw: string | null): string | null {
   return firstSentence.slice(0, 180).replace(/[,\s]+\S*$/, "") + "…";
 }
 
-function publishedDateLabel(iso: string | null): string | null {
-  if (!iso) return null;
-  try {
-    return new Date(iso).toLocaleDateString("en-AU", {
-      year: "numeric",
-      month: "long",
-    });
-  } catch {
-    return null;
-  }
-}
+/*
+ * No date is rendered, deliberately, and the reason is the same one recorded in
+ * FieldWriting: `publishedAt` in the editorial feed is a migration artifact
+ * rather than an editorial date. Twenty-one of the articles share one timestamp
+ * to the millisecond (2026-01-09T23:40:59.476Z) and five more share another
+ * (2026-03-25T22:45:19.558574Z); createdAt and updatedAt each hold a single
+ * value across the whole corpus.
+ *
+ * Until 2026-08-07 this reader printed that timestamp as "January 2026" under
+ * five unrelated headlines. The field pages had already stopped doing so. A
+ * date is a claim about when something happened, and this one is a claim about
+ * when a database row was written.
+ *
+ * Restore the label here, and in FieldWriting, once the feed carries real ones.
+ */
 
 export async function EditorialArticleReader({
   post,
@@ -81,8 +88,6 @@ export async function EditorialArticleReader({
   const preparedHtml = looksLikeHtml ? prepareArticleHtml(content) : null;
   const readingMinutes = readingTimeMinutes(content);
   const lede = shortLede(post.excerpt);
-  const dateLabel = publishedDateLabel(post.publishedAt);
-  const hasHero = !!post.featuredImageUrl;
 
   // Related project slugs resolved to the field pages that absorbed them.
   // Deduplicated, since several projects can land on the same field.
@@ -164,35 +169,15 @@ export async function EditorialArticleReader({
         ])}
       />
       <ReadingProgress />
-      {/* HERO: full-bleed image with title + meta overlay. Articles without a
-          featured image get a typographic cover — deep olive field with a low
-          clay glow — instead of a bare black rectangle. */}
+      {/* HERO: full-bleed image with title + meta overlay. The typographic
+          cover behind it carries any article whose photograph is absent or
+          dead; see ArticleHeroMedia. */}
       <section className="full-bleed relative min-h-[60vh] w-full overflow-hidden bg-[#11110F] md:min-h-[75vh]">
-        {hasHero ? (
-          <Image
-            src={post.featuredImageUrl!}
-            alt={post.featuredImageAlt ?? post.title}
-            fill
-            sizes="100vw"
-            className="object-cover"
-            priority
-          />
-        ) : (
-          <div
-            aria-hidden="true"
-            className="absolute inset-0 bg-[linear-gradient(150deg,#33402F_0%,#222B21_55%,#161B15_100%)]"
-          >
-            <div className="absolute inset-0 bg-[radial-gradient(ellipse_60%_50%_at_18%_88%,rgba(196,132,92,0.28),transparent_70%)]" />
-            <span className="absolute -bottom-24 right-[-4%] select-none font-[var(--font-display)] text-[38vw] font-light italic leading-none text-[#F3EBDD]/[0.05] md:text-[26vw]">
-              {post.title.charAt(0)}
-            </span>
-          </div>
-        )}
-        {hasHero ? (
-          <div className="absolute inset-0 bg-gradient-to-b from-black/25 via-black/45 to-black/80" />
-        ) : (
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/40" />
-        )}
+        <ArticleHeroMedia
+          imageUrl={post.featuredImageUrl ?? null}
+          alt={post.featuredImageAlt ?? post.title}
+          initial={post.title.charAt(0)}
+        />
         <div className="relative z-10 mx-auto flex min-h-[60vh] max-w-[1000px] flex-col justify-end px-6 pb-16 pt-32 md:min-h-[75vh] md:px-10 md:pb-24 md:pt-40">
           <Link
             href="/stories"
@@ -210,12 +195,6 @@ export async function EditorialArticleReader({
           ) : null}
           <div className="mt-8 flex flex-wrap items-center gap-5 font-[var(--font-sans)] text-[11px] uppercase tracking-[0.22em] text-[#CFA16B]/90">
             {post.authorName ? <span>{post.authorName}</span> : null}
-            {dateLabel ? (
-              <>
-                <span aria-hidden="true" className="text-[#CFA16B]/40">·</span>
-                <span>{dateLabel}</span>
-              </>
-            ) : null}
             {post.articleType ? (
               <>
                 <span aria-hidden="true" className="text-[#CFA16B]/40">·</span>
@@ -236,13 +215,17 @@ export async function EditorialArticleReader({
       <section className="bg-[#FBF6EC] px-6 py-20 md:px-10 md:py-28">
         <article className="mx-auto max-w-[720px]">
           {content ? (
-            <div className="rich-text">
-              {preparedHtml ? (
-                <div dangerouslySetInnerHTML={{ __html: preparedHtml }} />
-              ) : (
+            preparedHtml ? (
+              // Most of the corpus is exported HTML, and most of the dead
+              // photographs live inside it. RichTextMedia carries the .rich-text
+              // class the CSS keys off, so the wrapper div that used to sit
+              // outside it would now be a second, redundant .rich-text.
+              <RichTextMedia html={preparedHtml} />
+            ) : (
+              <div className="rich-text">
                 <ReactMarkdown>{content}</ReactMarkdown>
-              )}
-            </div>
+              </div>
+            )
           ) : (
             <p className="font-[var(--font-body)] italic text-[var(--we-warm-brown)]">
               This story has no public body yet. Its media, project links, and
@@ -252,60 +235,10 @@ export async function EditorialArticleReader({
         </article>
       </section>
 
-      {/* GALLERY: field photographs */}
-      {gallery.length > 0 && (
-        <section className="full-bleed bg-[#F6F1E7] px-6 py-20 md:px-10 md:py-28">
-          <div className="mx-auto max-w-[1300px]">
-            <p className="mb-8 text-center font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.35em] text-[var(--we-warm-brown)] md:mb-12">
-              Field photographs
-            </p>
-            <div
-              className={`grid gap-3 md:gap-4 ${
-                gallery.length === 1
-                  ? "mx-auto max-w-[900px] grid-cols-1"
-                  : gallery.length === 2
-                    ? "md:grid-cols-2"
-                    : "md:grid-cols-2 lg:grid-cols-3"
-              }`}
-            >
-              {gallery.map((photo, i) => {
-                const isBentoLead = i === 0 && gallery.length >= 3;
-                return (
-                  <div
-                    key={photo.url + i}
-                    className={`relative overflow-hidden rounded-[20px] bg-[#1B1A16] ${
-                      isBentoLead
-                        ? "aspect-[16/10] lg:col-span-2 lg:row-span-2 lg:aspect-[16/11]"
-                        : gallery.length === 1
-                          ? "aspect-[16/10]"
-                          : "aspect-[4/3]"
-                    }`}
-                  >
-                    <Image
-                      src={photo.url}
-                      alt={photo.alt || `Field photograph from ${post.title}`}
-                      fill
-                      sizes={isBentoLead
-                        ? "(min-width: 1024px) 66vw, (min-width: 768px) 100vw, 100vw"
-                        : gallery.length === 1
-                          ? "(min-width: 900px) 900px, 100vw"
-                          : "(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"}
-                      className="object-cover transition-transform duration-[6s] ease-out hover:scale-[1.03]"
-                    />
-                    {photo.caption ? (
-                      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent p-4 md:p-5">
-                        <p className="font-[var(--font-body)] text-[13px] italic leading-snug text-[#F3EBDD] md:text-base md:leading-normal">
-                          {photo.caption}
-                        </p>
-                      </div>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </section>
-      )}
+      {/* GALLERY: field photographs. Most of these URLs are dead upstream, so
+          the component drops what fails and hides itself when nothing loads. */}
+      <ArticleGallery photos={gallery} articleTitle={post.title} />
+
 
       {/* AUTHOR + CONNECTED FIELDS */}
       <section className="bg-[#FBF6EC] px-6 py-16 md:px-10 md:py-20">

--- a/src/components/editorial/ArticleGallery.tsx
+++ b/src/components/editorial/ArticleGallery.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+/**
+ * The field-photograph gallery on an editorial article, with dead images
+ * removed rather than framed.
+ *
+ * 81 of the 114 photograph URLs the editorial feed carries return HTTP 400
+ * from Empathy Ledger's storage (measured 2026-08-07). The featured image of
+ * every article survives; almost nothing else does. Because the gallery
+ * deliberately excludes the featured image, seventeen of the nineteen articles
+ * that have a gallery were rendering a bento grid in which *every* frame was
+ * dead: seven black rectangles filling a full screen of the page.
+ *
+ * Three things could fix that. Filtering at sync time is the right long-term
+ * home and needs Empathy Ledger to stop emitting URLs it cannot serve. A baked
+ * list of known-dead URLs in this repository would work today and drift by
+ * tomorrow. This is the third: let the browser be the source of truth. An
+ * image that fails to load removes itself, and a gallery with nothing left
+ * removes its whole section, heading included.
+ *
+ * The cost is a brief flash of empty frames before the errors land, which is
+ * why the frames are the page's own surface colour rather than the near-black
+ * they used to be: a photograph that has not arrived yet should look like a
+ * space waiting, not like a hole.
+ *
+ * This is defence, not a repair. The photographs are genuinely missing
+ * upstream, and no front-end change puts them back.
+ */
+
+export interface GalleryPhoto {
+  url: string;
+  alt: string;
+  caption: string | null;
+}
+
+export function ArticleGallery({
+  photos,
+  articleTitle,
+}: {
+  photos: GalleryPhoto[];
+  articleTitle: string;
+}) {
+  const [dead, setDead] = useState<string[]>([]);
+  const live = photos.filter((photo) => !dead.includes(photo.url));
+
+  if (live.length === 0) return null;
+
+  // Layout follows the surviving count, not the requested one, so an article
+  // left with a single photograph gets the single-photograph treatment rather
+  // than one image stranded in a three-column grid.
+  const columns =
+    live.length === 1
+      ? "mx-auto max-w-[900px] grid-cols-1"
+      : live.length === 2
+        ? "md:grid-cols-2"
+        : "md:grid-cols-2 lg:grid-cols-3";
+
+  return (
+    <section className="full-bleed bg-[#F6F1E7] px-6 py-20 md:px-10 md:py-28">
+      <div className="mx-auto max-w-[1300px]">
+        <p className="mb-8 text-center font-[var(--font-sans)] text-[11px] font-semibold uppercase tracking-[0.35em] text-[var(--we-warm-brown)] md:mb-12">
+          Field photographs
+        </p>
+        <div className={`grid gap-3 md:gap-4 ${columns}`}>
+          {live.map((photo, index) => {
+            const isBentoLead = index === 0 && live.length >= 3;
+            return (
+              <div
+                key={photo.url}
+                className={`relative overflow-hidden rounded-[20px] bg-[#EFE7D8] ${
+                  isBentoLead
+                    ? "aspect-[16/10] lg:col-span-2 lg:row-span-2 lg:aspect-[16/11]"
+                    : live.length === 1
+                      ? "aspect-[16/10]"
+                      : "aspect-[4/3]"
+                }`}
+              >
+                <Image
+                  src={photo.url}
+                  alt={photo.alt || `Field photograph from ${articleTitle}`}
+                  fill
+                  sizes={
+                    isBentoLead
+                      ? "(min-width: 1024px) 66vw, 100vw"
+                      : live.length === 1
+                        ? "(min-width: 900px) 900px, 100vw"
+                        : "(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+                  }
+                  className="object-cover transition-transform duration-[6s] ease-out hover:scale-[1.03]"
+                  onError={() =>
+                    setDead((current) =>
+                      current.includes(photo.url) ? current : [...current, photo.url],
+                    )
+                  }
+                />
+                {photo.caption ? (
+                  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent p-4 md:p-5">
+                    <p className="font-[var(--font-body)] text-[13px] italic leading-snug text-[#F3EBDD] md:text-base md:leading-normal">
+                      {photo.caption}
+                    </p>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/editorial/ArticleHeroMedia.tsx
+++ b/src/components/editorial/ArticleHeroMedia.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+/**
+ * The backdrop of an editorial article's hero, and what happens when the
+ * photograph behind it does not exist.
+ *
+ * The reader already had a considered treatment for an article with no
+ * featured image: a deep olive field, a low clay glow, and the title's first
+ * letter set enormous and barely visible. It was only ever reached when the
+ * feed said there was no image at all. Two articles say there is one and point
+ * at a URL that returns 400 (wilya-janta and edition-1-sowing-seeds-of-
+ * connection-2, measured 2026-08-07), and those landed on the plain near-black
+ * rectangle the photograph was meant to cover.
+ *
+ * So the typographic cover is now the floor rather than a branch. It renders
+ * underneath every hero; a photograph that loads simply covers it. Nothing
+ * flashes, because the cover is painted first and the photograph arrives on
+ * top of it in the ordinary way.
+ *
+ * Only the scrim changes on failure. The photograph scrim is heavy enough to
+ * hold white text over an unpredictable image, and that same weight over the
+ * olive would leave the cover looking like a mistake rather than a decision.
+ */
+
+export function ArticleHeroMedia({
+  imageUrl,
+  alt,
+  initial,
+}: {
+  imageUrl: string | null;
+  alt: string;
+  initial: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const showingPhotograph = Boolean(imageUrl) && !failed;
+
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[linear-gradient(150deg,#33402F_0%,#222B21_55%,#161B15_100%)]"
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_60%_50%_at_18%_88%,rgba(196,132,92,0.28),transparent_70%)]" />
+        <span className="absolute -bottom-24 right-[-4%] select-none font-[var(--font-display)] text-[38vw] font-light italic leading-none text-[#F3EBDD]/[0.05] md:text-[26vw]">
+          {initial}
+        </span>
+      </div>
+
+      {imageUrl && !failed ? (
+        <Image
+          src={imageUrl}
+          alt={alt}
+          fill
+          sizes="100vw"
+          className="object-cover"
+          priority
+          onError={() => setFailed(true)}
+        />
+      ) : null}
+
+      <div
+        className={
+          showingPhotograph
+            ? "absolute inset-0 bg-gradient-to-b from-black/25 via-black/45 to-black/80"
+            : "absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/40"
+        }
+      />
+    </>
+  );
+}

--- a/src/components/editorial/ArticleHeroMedia.tsx
+++ b/src/components/editorial/ArticleHeroMedia.tsx
@@ -64,7 +64,7 @@ export function ArticleHeroMedia({
       <div
         className={
           showingPhotograph
-            ? "absolute inset-0 bg-gradient-to-b from-black/25 via-black/45 to-black/80"
+            ? "absolute inset-0 bg-gradient-to-b from-black/30 via-black/60 to-black/85"
             : "absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/40"
         }
       />

--- a/src/components/editorial/RichTextMedia.tsx
+++ b/src/components/editorial/RichTextMedia.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Wraps an article's rich-text body and removes photographs that never arrive.
+ *
+ * Production carries 107 dead image URLs across 18 of its 21 story pages
+ * (measured 2026-08-07 against act-regenerative-studio.vercel.app). Most of
+ * them are not in the gallery at the foot of the page; they are inside the
+ * prose, where Empathy Ledger's exported HTML embeds them directly. A reader
+ * of "At the Speed of Ceremony" met eighteen broken frames while reading.
+ *
+ * The body is injected with dangerouslySetInnerHTML, so those images are not
+ * React elements and cannot take an onError prop. This listens for `error` on
+ * the capture phase instead, which is the only way to catch it: error events
+ * from an <img> do not bubble.
+ *
+ * When a photograph fails, its whole <figure> goes, not just the <img>. Half
+ * of these images sit in a figure with a caption, and a caption describing a
+ * photograph nobody can see is worse than no photograph at all.
+ *
+ * Hiding rather than removing keeps the DOM stable for anything that may have
+ * measured it, and `aria-hidden` keeps the empty node out of a screen reader.
+ *
+ * This treats the symptom. The photographs are genuinely missing from Empathy
+ * Ledger's storage, and only a re-upload there puts them back; see
+ * scripts/check-editorial-media.mjs for the measurement that watches it.
+ */
+
+function conceal(image: HTMLImageElement) {
+  const target = image.closest("figure") ?? image;
+  if (!(target instanceof HTMLElement)) return;
+  target.style.display = "none";
+  target.setAttribute("aria-hidden", "true");
+}
+
+export function RichTextMedia({ html }: { html: string }) {
+  const container = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const node = container.current;
+    if (!node) return;
+
+    // Images that failed before this effect ran never fire an event we can
+    // catch, so the already-broken ones are swept first. A complete image with
+    // no intrinsic width is one the browser tried and could not decode.
+    for (const image of node.querySelectorAll("img")) {
+      if (image.complete && image.naturalWidth === 0) conceal(image);
+    }
+
+    const onError = (event: Event) => {
+      if (event.target instanceof HTMLImageElement) conceal(event.target);
+    };
+    node.addEventListener("error", onError, true);
+    return () => node.removeEventListener("error", onError, true);
+  }, [html]);
+
+  return (
+    <div
+      ref={container}
+      className="rich-text"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}


### PR DESCRIPTION
Production was serving **107 dead images across 18 of its 21 story pages**. "At the Speed of Ceremony" carried eighteen broken frames through its prose; seventeen articles rendered a full screen of black rectangles where the gallery should be. Measured twice against `act-regenerative-studio.vercel.app` on 2026-08-07, and the new gate reproduces it exactly at 181 live / 107 dead.

## Why it happened

Empathy Ledger moved its media to `empathyledger.com/api/media/<id>/file` and rewrote the **structured** fields, so heroes and galleries resolve. It did not rewrite the **exported article HTML**, so every photograph embedded in the prose still points at the retired Supabase bucket, which answers 400 with a JSON body. Empathy Ledger's own article pages show the same damage, which is how we know it is not this site's configuration.

**Nothing here puts a photograph back.** This stops them being framed, and adds the measurement that will notice next time.

## Photographs that never arrive

- `RichTextMedia` hides a body photograph that fails, and its whole `<figure>` when it has one, because a caption describing an image nobody can see is worse than no image. Error events from an `img` do not bubble, so it listens on the capture phase and sweeps the already-broken before it starts.
- `ArticleGallery` drops photographs that fail and hides its own section, heading and all, when none survive. The gallery excludes the featured image and the featured image was usually the only one that loaded, which is why seventeen articles showed nothing but black.
- `ArticleHeroMedia` makes the typographic cover the floor under every hero rather than a branch reached only when the feed admits it has no image. Two articles claim a hero and point at a 400.

## Two claims that were not true

"One place. Many voices." sat above twenty-one pieces carrying one byline. The line beneath it said each story stays connected to "its people and its permissions" when the feed carries no per-story consent record at all. Both are the kind of claim we ask funders not to make. The authorship is now stated plainly in the publishing-model section instead of implied away.

The reader also stops printing a date. `publishedAt` is a migration timestamp shared to the millisecond across most of the corpus, and the field pages had already stopped showing it.

## Hero text, measured rather than eyeballed

`/stories/[slug]` was never in the contrast gate's route list: the longest page on the site, and the only one laying text over an arbitrary photograph. The gate skips text over media by design and correctly, so the hero was measured by sampling rendered pixels across five articles.

| element | before | needs | result |
|---|---|---|---|
| "All stories" link | 1.58 – 4.18 | 4.5 | failed on 5 of 5 |
| title | 2.74 – 10.52 | 3 | failed on CONTAINED |
| meta line | 3.83 – 7.51 | 4.5 | failed on CONTAINED |

The scrim moves from 25/45/80 to 30/60/85, which carries the title and meta everywhere (CONTAINED's title 2.74 → 4.43, its meta 3.83 → 5.16) with nothing regressing.

No scrim rescues the "All stories" link. It is clay-gold, a mid tone at luminance 0.397, and clearing 4.5 against a bright photograph needs about 95% black behind it, which is a slab laid over the photograph rather than a scrim across it. It moves below the hero onto the body surface, forest green on `#FBF6EC` at 7.38, where contrast is deterministic. Direct arrivals from search keep a route back, and the header carries Stories on every page regardless.

## Gates

- `npm run check:media` probes rendered story pages, baseline 107, so new rot fails and known damage does not. It checks pages rather than the committed snapshot, which goes stale between syncs and disagreed with production in both directions.
- `check-contrast.mjs` now resolves one story article at run time. Article slugs come from Empathy Ledger and change without notice; a hard-coded one would fail on an upstream edit rather than a real regression. 26 routes, no violations.

`tsc` clean, 22 tests pass, `check:copy` clean.

## Not done, and why

- **The Empathy Ledger body-HTML rewrite** is the actual fix and belongs upstream. One migration pass returns 107 photographs to these pages.
- **`utopia-may-2026` stays orphaned.** It is `status: 'public-preview'`, noindexed, and carries `visibility: 'internal'` blocks with placeholders reading "Do not replace until consent is cleared". It is correctly held, not neglected. `StoryScroll` is a good renderer with no published story using it, which is an editorial gap rather than a wiring bug.
- **The 2,164-image project media library stays unpublished.** It is live and reachable and appears on almost no public page, but 118 of 2,164 have a caption, **0 have a credit**, and 75 name the people in them. Publishing it would repeat the failure that already forced the `/storytellers` and `/people` holds. Gated on consent metadata, not on UI work.

No file overlap with #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
