### PR TITLE
Stories: the last six broken frames, in the Keep reading cards

### DIFF
--- a/src/app/stories/[slug]/editorial-article.tsx
+++ b/src/app/stories/[slug]/editorial-article.tsx
@@ -18,6 +18,7 @@ import { ReadingProgress } from "@/components/editorial/ReadingProgress";
 import { ArticleGallery } from "@/components/editorial/ArticleGallery";
 import { RichTextMedia } from "@/components/editorial/RichTextMedia";
 import { ArticleHeroMedia } from "@/components/editorial/ArticleHeroMedia";
+import { SuggestedCardImage } from "@/components/editorial/SuggestedCardImage";
 import {
   fieldsForArticle,
   projectSlugDestination,
@@ -379,21 +380,10 @@ export async function EditorialArticleReader({
                   className="group flex flex-col overflow-hidden rounded-[24px] border border-[var(--we-sand)] bg-white/80 transition-all hover:-translate-y-1 hover:border-forest hover:shadow-[0_20px_50px_-20px_rgba(47,62,46,0.18)]"
                 >
                   <div className="relative aspect-[16/10] overflow-hidden bg-[#F5F0E8]">
-                    {other.featuredImageUrl ? (
-                      <Image
-                        src={other.featuredImageUrl}
-                        alt={other.featuredImageAlt ?? other.title}
-                        fill
-                        sizes="(min-width: 768px) 33vw, 100vw"
-                        className="object-cover transition-transform duration-[6s] ease-out group-hover:scale-[1.04]"
-                      />
-                    ) : (
-                      <div className="flex h-full items-center justify-center">
-                        <span className="font-[var(--font-sans)] text-[10px] uppercase tracking-[0.3em] text-[var(--we-warm-brown)]/40">
-                          Editorial
-                        </span>
-                      </div>
-                    )}
+                    <SuggestedCardImage
+                      src={other.featuredImageUrl ?? null}
+                      alt={other.featuredImageAlt ?? other.title}
+                    />
                   </div>
                   <div className="flex flex-1 flex-col space-y-3 p-6">
                     <p className="font-[var(--font-sans)] text-[10px] font-semibold uppercase tracking-[0.3em] text-[var(--we-warm-brown)]">

--- a/src/components/editorial/SuggestedCardImage.tsx
+++ b/src/components/editorial/SuggestedCardImage.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+/**
+ * The thumbnail on a "Keep reading" card, and what it does when the
+ * photograph behind it is gone.
+ *
+ * These cards already had a treatment for an article with no image: the tile
+ * sets the word "Editorial" small and faint on the card's own sand colour. It
+ * was only ever reached when the feed said there was no image, never when the
+ * feed named one that answers 400.
+ *
+ * That gap was the last visible damage from the Empathy Ledger media move. The
+ * article body, gallery and hero were all given a fallback in the first pass
+ * and eighteen of twenty-one live story pages came back clean; the remaining
+ * three each showed two broken frames, and every one of them was here, at the
+ * foot of the page, in a card recommending another article.
+ *
+ * A suggestion is worth less than the thing it points at, so this fails to the
+ * quiet tile rather than doing anything cleverer.
+ */
+
+export function SuggestedCardImage({
+  src,
+  alt,
+}: {
+  src: string | null;
+  alt: string;
+}) {
+  const [failed, setFailed] = useState(false);
+
+  if (!src || failed) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <span className="font-[var(--font-sans)] text-[10px] uppercase tracking-[0.3em] text-[var(--we-warm-brown)]/40">
+          Editorial
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      fill
+      sizes="(min-width: 768px) 33vw, 100vw"
+      className="object-cover transition-transform duration-[6s] ease-out group-hover:scale-[1.04]"
+      onError={() => setFailed(true)}
+    />
+  );
+}


### PR DESCRIPTION
Follow-up to #63, found by verifying it against production rather than assuming it worked.

#63 left **eighteen of twenty-one live story pages clean**. Three still showed two broken frames each, and all six were in the same place: the "Keep reading" cards at the foot of the article.

The cards already had a treatment for an article with no image, a quiet "Editorial" tile on the card's own sand colour. Like the hero before it, that was a branch reached only when the feed admitted it had no image, never when the feed named one that answers 400. `SuggestedCardImage` makes it the fallback for both cases.

A suggestion is worth less than the thing it points at, so it fails to the quiet tile rather than doing anything cleverer.

## Also checked, and deliberately not changed

Two of the three affected articles render through `ReactMarkdown` rather than the HTML branch, which was the obvious next suspect. Neither carries an inline image, so that branch has nothing to protect. Left alone rather than wrapped speculatively.

`tsc` clean, 22 tests pass, `check:copy` clean.

Verification after this lands: all 21 live story pages should report 0 visible broken images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
