### PR TITLE
check:media: retry a non-image response, not just a thrown fetch

### DIFF
--- a/scripts/check-editorial-media.mjs
+++ b/scripts/check-editorial-media.mjs
@@ -89,16 +89,26 @@ function imageUrls(html) {
  * packet. A refusal that survives three attempts is treated as real.
  */
 async function probe(url, attempt = 0) {
+  const retry = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+    return probe(url, attempt + 1);
+  };
+
   try {
     const response = await fetch(url);
     const contentType = response.headers.get("content-type") || "";
     await response.arrayBuffer();
-    return { url, status: response.status, live: response.ok && contentType.startsWith("image/") };
+    const live = response.ok && contentType.startsWith("image/");
+    // Anything that is not an image gets retried before it counts. The gated
+    // route 302s to a signed URL, so a photograph's delivery crosses two hosts
+    // and can pick up a 429 or a 5xx from either; the first run at baseline 0
+    // reported one dead photograph that a re-run showed live. A genuinely
+    // retired URL answers 400 every time and still fails all three attempts.
+    if (!live && attempt < 2) return retry();
+    return { url, status: response.status, live };
   } catch (error) {
-    if (attempt < 2) {
-      await new Promise((resolve) => setTimeout(resolve, 400 * (attempt + 1)));
-      return probe(url, attempt + 1);
-    }
+    // A thrown fetch is a transport failure rather than an answer.
+    if (attempt < 2) return retry();
     return { url, status: 0, live: false, error: String(error).slice(0, 120) };
   }
 }


### PR DESCRIPTION
The gate caught its own flakiness on the first run at baseline 0: it failed with one dead photograph, and a re-run showed 201 live / 0 dead.

A flaky gate at baseline 0 fails CI on an upstream blip and teaches everyone to ignore it — the exact thing this script's own comments warn against.

## Cause

The retry only fired when `fetch` **threw**. A photograph now travels through `/api/media/:id/file`, which 302s to a signed Supabase URL, so delivery crosses two hosts and can pick up a 429 or 5xx from either. Those return a *response* with a non-image content type, not an exception — so they counted as dead on the first look, with no second one.

## Fix

Anything that is not an image is retried up to twice before it counts.

## Verified both directions

- Production: **201 live / 0 dead**, passes at baseline 0
- A retired URL from the old public bucket (`.../conversation-camp/c7887204b7ac69a7.jpg`) still answers 400 on all three attempts and is still reported dead — the retry does not mask real losses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
