### PR TITLE
EL data asks: add what a day inside the data turned up, and reorder the priority

### DIFF
--- a/docs/integrations/empathy-ledger/data-asks.md
+++ b/docs/integrations/empathy-ledger/data-asks.md
@@ -62,3 +62,73 @@ exist and are empty. The fifth is a question about which key is authoritative.
 The dates. Everything else degrades gracefully, and a reader can live without a
 caption. A body of work with no dates reads as abandoned, and the site currently
 chooses silence over stating something untrue.
+
+---
+
+# Added 2026-08-08, after a day inside the data
+
+Everything above still holds. What follows was found while restoring 107 dead
+photographs, and it changes the priority order: **the consent asks now outrank
+the dates.** Each figure below was measured directly against the Empathy Ledger
+database on 2026-08-08, not inferred.
+
+## 6. Elder review is recorded nowhere, on material that plainly needs it
+
+`syndication_consent` holds 40 rows for the `act-regenerative-studio` site: 37
+approved, 38 article-scoped, and every live article covered. That part is in
+good order and better than the wiki suggests.
+
+But across all 40 rows, `requires_elder_approval` is false, `elder_approved` is
+false, and `cultural_permission_level` is null. Meanwhile **14 of the live
+articles use the words Elder, Country, Traditional Owner, custodian, ceremony or
+sorry business**, with titles including "walking with Elders on Kalkadoon
+Country" and "a day on Quandamooka Country".
+
+The schema has the columns. Nothing populates them, and `/admin/elder-review`
+reviews photographs rather than articles, so there is no path to set them.
+
+**What we need:** a way to flag an article as requiring elder review, and to
+record who gave it and when. The org-level approval pattern already treats a
+Traditional Owner's approval as satisfying elder review; the article-level
+fields should be able to record the same thing.
+
+## 7. The wiki and the database disagree about public-web permission
+
+The org-level story approvals in `act-global-infrastructure/wiki/decisions/`
+each name public-internet publication under "What is NOT approved". The database
+says the opposite: approved, unrevoked consent rows exist for this site,
+including for the story those records name by title.
+
+Two systems holding the same decision in different words produced a false alarm
+on 2026-08-08, and would have produced a wrong takedown had it been acted on.
+
+**What we need:** the decision records to defer to `syndication_consent` rather
+than restate it. Empathy Ledger is the system of record; the wiki should point
+at it.
+
+## 8. The media gate fails open
+
+`resolveAssetUrl` ends `return gated ?? url`. A storage path absent from the map,
+because the lookup errored or the asset is not registered, ships the raw
+public-storage URL. That is the ungated form the gate exists to stop emitting.
+
+For a consent gate, failing closed is the safer default: withholding a
+photograph is recoverable, shipping an unrevocable one is not.
+
+**What we need:** a decision on the default, applied to both content-hub routes
+together.
+
+## 9. Captions, restated at the real scale
+
+The 123 figure above counts article media. The wider project library is larger
+and in worse shape: **2,164 images, 118 with a caption, 0 with a credit**, 75
+with named people, 447 with a description that is not a filename.
+
+This is why the site publishes none of it. It is not a design backlog; it is the
+reason a photographic surface cannot honestly exist yet.
+
+## Revised: if only one thing gets done
+
+Not the dates any more. **Elder review**, because it is the only item on this
+list where being wrong harms somebody rather than merely reading poorly. The
+dates remain the best thing to do second.

--- a/docs/integrations/empathy-ledger/elder-review-conversations.md
+++ b/docs/integrations/empathy-ledger/elder-review-conversations.md
@@ -1,0 +1,157 @@
+# Elder review: what to ask, and who to ask it of
+
+**Written 2026-08-08. This is preparation for conversations, not a decision.**
+
+ACT is not a First Nations organisation and does not hold this authority. Nothing
+in here decides anything. It exists so that when the conversations happen, they
+happen on accurate facts rather than on what anyone assumed was true.
+
+Every figure below was measured against the Empathy Ledger database on
+2026-08-08.
+
+---
+
+## Where things actually stand
+
+Better than it first looked, and worse in one specific way.
+
+**The consent record exists and is in order.** `syndication_consent` holds 40
+rows for the `act-regenerative-studio` site: 37 approved, 38 article-scoped,
+and every live article covered by an approved, unrevoked row. Nobody published
+anything without a record.
+
+**A first pass got this wrong**, and the mistake is worth knowing because it
+will recur. The org-level story approvals in
+`act-global-infrastructure/wiki/decisions/` each name public-internet
+publication under "What is NOT approved". Read alone, that says the site is in
+breach. The database says the opposite. Empathy Ledger is the system of record;
+the wiki records are older and were never updated. **Read the database first.**
+
+**What is genuinely missing is elder review.** Across all 40 consent rows:
+
+| field | value on every row |
+| --- | --- |
+| `requires_elder_approval` | false |
+| `elder_approved` | false |
+| `elder_approved_by` | null |
+| `cultural_permission_level` | null |
+
+The columns exist. Nothing has ever filled them. And `/admin/elder-review`
+reviews photographs, not articles, so there is currently no path to fill them
+even if someone wanted to.
+
+---
+
+## The twelve live articles that carry culturally weighted material
+
+Grouped by the community the work sits with, because that is who the question
+belongs to. Counts are mentions in the article body.
+
+### Palm Island — Bwgcolman
+- **At the Speed of Ceremony: Learning Partnership on Palm Island**
+  5 mentions of Elders, references ceremony. The most heavily weighted piece on
+  the site.
+
+### Quandamooka
+- **Between Waters and Worlds: A Day on Quandamooka Country**
+  7 mentions of Country, 2 of Elders, references ceremony.
+
+### Kalkadoon — Mount Isa
+- **Seeds of Change: Walking with Elders and Youth on Kalkadoon Country**
+  14 mentions of Country, names Traditional Owners, references ceremony. Elders
+  are in the title.
+
+### Warumungu — Tennant Creek
+- **Wilya Janta: A Paradigm Shift in Housing for Remote Aboriginal Communities**
+- **NAIDOC with Jimmy** — names a Traditional Owner
+  Jimmy Frank Jupurrurla leads this work and holds cultural authority for the
+  Country it is from.
+
+### Arrernte — Mparntwe
+- **Oonchiumpa: What Happens When Community Leads**
+  Named at line 37 of the Oonchiumpa approval as one of the six stories it
+  covers. Kristy Bloomfield (Central Arrernte, Eastern Arrernte, Alyawarra
+  Traditional Owner of Mparntwe) and Tanya Turner are the co-directors who gave
+  the original verbal approval.
+
+### Not tied to one community
+- The Spirit Must Be Strong
+- History's Wounds and Tomorrow's Possibilities
+- The Kids Are Not Alright
+- JusticeHub: A Platform for Community-Led Justice Solutions
+- The Power of Indigenous Storytelling
+- Life is hard, but it's not
+
+Two further weighted articles, *From Bolivia to Brisbane* and *Edition #1*, are
+already withheld by ACT's own withdrawal tombstone and are not public.
+
+---
+
+## The questions worth bringing
+
+Phrased so they can be answered, and so that "no" and "not yet" are as easy to
+say as "yes". The existing approval pattern is verbal consent in conversation
+with community leaders, witnessed and written down promptly. That pattern
+already works; these are the questions it has not yet been asked.
+
+**1. Is the public website in scope?**
+The approvals name the wiki, the campaign work, the Minderoo envelope and Judges
+on Country. They do not name a public website. The database says yes; the wiki
+says no. Which was meant?
+
+**2. Does this piece need elder review, and has it had one?**
+Per article, for the twelve above. The system can record who gave it and when.
+It currently records nothing.
+
+**3. Where a leader holds Traditional Owner authority for the Country a story
+comes from, does their approval satisfy elder review?**
+The Oonchiumpa record already sets this precedent for Kristy Bloomfield. It
+would be worth knowing whether it holds for Jimmy Frank Jupurrurla and for the
+Palm Island and Kalkadoon work, or whether those need a separate review.
+
+**4. Is there anything here that should come down now?**
+Not as a hypothetical. Twelve specific pieces, listed above, are public today.
+
+**5. What should happen with the photographs?**
+2,164 images sit in the project library. 118 have a caption. None has a credit.
+75 have named people. None of it is published, and it will not be until this is
+answered, but the question of what those photographs are for is worth asking
+alongside the writing.
+
+---
+
+## What each answer unblocks
+
+- **Yes, in scope, elder review given** → record it in `syndication_consent`
+  (`elder_approved`, `elder_approved_by`, `elder_approved_at`), and the record
+  finally matches the practice.
+- **Yes, but this piece needs review first** → set `requires_elder_approval` and
+  withhold that slug via `config/withdrawn-editorial.json` until it clears. The
+  withdrawal path is already built, already enforced at both the sync and the
+  serving layer, and takes effect on the next sync.
+- **No, or not yet** → same mechanism, and nothing is lost. Withheld articles are
+  never deleted, only made non-public.
+- **No answer yet** → the honest position is that the pieces stay up under the
+  consent that does exist, and this document records what is still unasked.
+
+---
+
+## What ACT should fix regardless of the answers
+
+Three things that are ours, not the Elders':
+
+1. **There is no way to record an article-level elder review.** The columns
+   exist; the admin surface reviews photographs instead. Until that is built,
+   even a clear "yes" cannot be written down.
+2. **The wiki records contradict the database.** They should point at
+   `syndication_consent` rather than restate it. The contradiction already
+   produced one false alarm.
+3. **The media gate fails open.** An asset missing from the gate map ships a raw,
+   unrevocable URL. Failing closed is the safer default for consent-bearing
+   media.
+
+---
+
+*Related: `data-asks.md` in this directory, and the Oonchiumpa approval at*
+*`act-global-infrastructure/wiki/decisions/2026-04-18-oonchiumpa-story-approval.md`,*
+*which sets the verbal-consent governance pattern this builds on.*

--- a/docs/integrations/empathy-ledger/record-elder-review.sql
+++ b/docs/integrations/empathy-ledger/record-elder-review.sql
@@ -1,0 +1,188 @@
+-- Record elder review against the articles syndicated to act-regenerative-studio.
+--
+-- Run against the Empathy Ledger project (yvnuayzslukamizrlhwb).
+-- Written 2026-08-08. This writes to a consent ledger, so read the whole header.
+--
+--
+-- WHY THIS FILE EXISTS AND WHY IT IS NOT ALREADY FILLED IN
+--
+-- syndication_consent has the columns for elder review and every one of the 40
+-- rows for this site has them empty: requires_elder_approval false,
+-- elder_approved false, elder_approved_by null, cultural_permission_level null.
+-- Twelve live articles carry culturally weighted material. So a real approval
+-- currently has nowhere to go, and this is the path.
+--
+-- It is deliberately not pre-filled. `elder_approved_by` is a uuid, not a note:
+-- the schema itself insists that an approval is attached to an identified
+-- person. Writing a row that says approved without saying truthfully by whom,
+-- when, and in what setting would manufacture the audit trail the ledger exists
+-- to hold. The governing rule from the Oonchiumpa decision is that verbal
+-- consent in conversation IS first-class at ACT, and that the written record is
+-- the witness writing it down promptly and accurately. That is what the
+-- variables below are for.
+--
+--
+-- ONE UPDATE PER COMMUNITY, NOT ONE FOR EVERYTHING
+--
+-- The twelve articles sit with at least five different authorities: Bwgcolman
+-- (Palm Island), Quandamooka, Kalkadoon, Warumungu (Tennant Creek) and Arrernte
+-- (Mparntwe). A single blanket UPDATE would record one person as having
+-- approved another community's material, which is both false and the precise
+-- failure OCAP exists to prevent. Each block below stands alone. Run only the
+-- blocks you have an actual approval for; leave the rest untouched.
+--
+-- The Oonchiumpa precedent covers one case: where the person approving holds
+-- Traditional Owner authority for the Country the stories are from, their
+-- approval satisfies elder review for their org's material. Where they do not,
+-- org approval is not a substitute and a separate elder review is needed.
+--
+--
+-- KNOWN IDENTITIES (verified present in storytellers, 2026-08-08)
+--
+--   Kristy Bloomfield  b59a1f4c-94fd-4805-a2c5-cac0922133e0
+--   Tanya Turner       dc85700d-f139-46fa-9074-6afee55ea801
+--   Jimmy Frank        dda39576-ae9e-49e6-9bf9-70fcb45835ba
+--
+-- Anyone else giving approval needs their storyteller id looked up first. Do not
+-- invent one and do not reuse a near-match.
+--
+--
+-- BEFORE RUNNING
+--   1. Fill the variables in each block you intend to run.
+--   2. Run the DRY RUN and read which articles it names.
+--   3. Run the block.
+--   4. Run the VERIFY at the foot.
+
+
+-- ---------------------------------------------------------------------------
+-- DRY RUN. Read-only. Shows current elder-review state per live article.
+-- ---------------------------------------------------------------------------
+select a.slug,
+       sc.status,
+       sc.requires_elder_approval,
+       sc.elder_approved,
+       s.display_name as elder_approved_by,
+       sc.elder_approved_at,
+       sc.cultural_permission_level
+from articles a
+join syndication_consent sc
+  on sc.article_id = a.id
+ and sc.site_id = (select id from syndication_sites where slug = 'act-regenerative-studio')
+left join storytellers s on s.id = sc.elder_approved_by
+where a.syndication_enabled and a.status = 'published' and a.visibility = 'public'
+order by a.slug;
+
+
+-- ---------------------------------------------------------------------------
+-- BLOCK A — Arrernte / Mparntwe (Oonchiumpa)
+--
+-- Precedent already recorded: Kristy Bloomfield is a Traditional Owner of
+-- Mparntwe and Oonchiumpa operates on her Country, so her approval is elder
+-- review in the OCAP sense for Oonchiumpa material.
+-- ---------------------------------------------------------------------------
+-- \set approver_id 'b59a1f4c-94fd-4805-a2c5-cac0922133e0'
+-- \set approved_on '2026-__-__'
+-- \set channel     'verbal in conversation, witnessed by Ben Knight'
+
+/*
+update syndication_consent sc
+   set requires_elder_approval  = true,
+       elder_approved           = true,
+       elder_approved_by        = 'b59a1f4c-94fd-4805-a2c5-cac0922133e0'::uuid,
+       elder_approved_at        = 'YYYY-MM-DD'::timestamptz,
+       cultural_permission_level = 'community-approved',
+       updated_at               = now()
+  from articles a
+ where sc.article_id = a.id
+   and sc.site_id = (select id from syndication_sites where slug = 'act-regenerative-studio')
+   and a.slug in ('oonchiumpa-what-happens-when-community-leads');
+*/
+
+
+-- ---------------------------------------------------------------------------
+-- BLOCK B — Warumungu / Tennant Creek (Wilya Janta, NAIDOC with Jimmy)
+-- Approver must hold authority for that Country. Jimmy Frank leads this work.
+-- ---------------------------------------------------------------------------
+/*
+update syndication_consent sc
+   set requires_elder_approval  = true,
+       elder_approved           = true,
+       elder_approved_by        = 'dda39576-ae9e-49e6-9bf9-70fcb45835ba'::uuid,
+       elder_approved_at        = 'YYYY-MM-DD'::timestamptz,
+       cultural_permission_level = 'community-approved',
+       updated_at               = now()
+  from articles a
+ where sc.article_id = a.id
+   and sc.site_id = (select id from syndication_sites where slug = 'act-regenerative-studio')
+   and a.slug in (
+     'wilya-janta-a-paradigm-shift-in-housing-for-remote-aboriginal-communities',
+     'naidoc-with-jimmy'
+   );
+*/
+
+
+-- ---------------------------------------------------------------------------
+-- BLOCK C — Bwgcolman / Palm Island
+-- No approver identity recorded yet. Look one up before filling this in.
+--   at-the-speed-of-ceremony-learning-partnership-on-palm-island
+-- ---------------------------------------------------------------------------
+
+
+-- ---------------------------------------------------------------------------
+-- BLOCK D — Quandamooka
+--   between-waters-and-worlds-a-day-on-quandamooka-country
+-- ---------------------------------------------------------------------------
+
+
+-- ---------------------------------------------------------------------------
+-- BLOCK E — Kalkadoon / Mount Isa
+--   seeds-of-change-walking-with-elders-and-youth-on-kalkadoon-country
+-- ---------------------------------------------------------------------------
+
+
+-- ---------------------------------------------------------------------------
+-- BLOCK F — not tied to one community
+--
+-- These six mention Elders or Country without sitting with one authority. They
+-- may need no elder review at all, or may need one per piece. That is a
+-- judgement to make with the people concerned, not a default to apply:
+--   the-spirit-must-be-strong
+--   historys-wounds-and-tomorrows-possibilities
+--   the-kids-are-not-alright-...
+--   justicehub-a-platform-for-community-led-justice-solutions
+--   the-power-of-indigenous-storytelling-a-community-perspective
+--   life-is-hard-but-its-not
+-- ---------------------------------------------------------------------------
+
+
+-- ---------------------------------------------------------------------------
+-- AUDIT. Run once per block, with the same facts, so the ledger carries the
+-- provenance and not only the flag.
+-- ---------------------------------------------------------------------------
+/*
+insert into syndication_audit_log (site_id, action, details, created_at)
+select (select id from syndication_sites where slug = 'act-regenerative-studio'),
+       'elder_review_recorded',
+       jsonb_build_object(
+         'community',   'Arrernte / Mparntwe',
+         'approver',    'Kristy Bloomfield',
+         'approver_id', 'b59a1f4c-94fd-4805-a2c5-cac0922133e0',
+         'given_on',    'YYYY-MM-DD',
+         'channel',     'verbal in conversation',
+         'witnessed_by','Ben Knight',
+         'scope',       'in the approver''s own words, if remembered',
+         'articles',    jsonb_build_array('oonchiumpa-what-happens-when-community-leads')
+       ),
+       now();
+*/
+
+
+-- ---------------------------------------------------------------------------
+-- VERIFY
+-- ---------------------------------------------------------------------------
+select count(*) filter (where sc.elder_approved)            as elder_approved,
+       count(*) filter (where sc.requires_elder_approval)   as flagged_as_requiring,
+       count(*) filter (where sc.elder_approved_by is null
+                          and sc.elder_approved)            as approved_but_unattributed  -- must be 0
+from syndication_consent sc
+where sc.site_id = (select id from syndication_sites where slug = 'act-regenerative-studio');

--- a/docs/integrations/empathy-ledger/record-elder-review.sql
+++ b/docs/integrations/empathy-ledger/record-elder-review.sql
@@ -80,23 +80,69 @@ order by a.slug;
 -- Mparntwe and Oonchiumpa operates on her Country, so her approval is elder
 -- review in the OCAP sense for Oonchiumpa material.
 -- ---------------------------------------------------------------------------
--- \set approver_id 'b59a1f4c-94fd-4805-a2c5-cac0922133e0'
--- \set approved_on '2026-__-__'
--- \set channel     'verbal in conversation, witnessed by Ben Knight'
+-- READY TO RUN as of 2026-08-08. Ben confirmed Kristy has given approval.
+--
+-- Scope is one article. Two further live articles mention Oonchiumpa
+-- (historys-wounds-and-tomorrows-possibilities and
+-- justicehub-a-platform-for-community-led-justice-solutions) but they are
+-- ACT-authored pieces about ACT's work rather than Oonchiumpa stories, and are
+-- deliberately excluded. Mentioning a community is not the same as the story
+-- belonging to them. If Kristy's approval is meant to cover them, add them
+-- explicitly rather than widening the rule.
+--
+-- elder_approved_at is set to now(), which is the date this was RECORDED, not
+-- the date the approval was given. The conversation date was not specified. The
+-- audit row says so in as many words. Correct both if the real date is known.
 
-/*
+-- EXECUTED 2026-08-08 03:04 UTC. Kept as the record of what ran.
+--
+-- Two corrections were forced by the schema and are worth carrying forward:
+--
+--   cultural_permission_level is NOT set. Its check constraint allows only
+--   public / community / restricted / sacred, which describe the material's
+--   sensitivity tier rather than who approved it. An elder-review approval does
+--   not state a tier, so inferring one would be inventing a fact. Left null.
+--
+--   event_type has no elder-review value. The audit log allows consent_granted,
+--   consent_revoked, content_accessed, content_shared, profile_viewed,
+--   story_clicked, profile_synced, token_created, token_revoked, and nothing
+--   else. consent_granted is the nearest true value; the metadata carries
+--   consent_kind so the record is not ambiguous. Adding an elder_review_recorded
+--   event type would be the better fix.
+
 update syndication_consent sc
-   set requires_elder_approval  = true,
-       elder_approved           = true,
-       elder_approved_by        = 'b59a1f4c-94fd-4805-a2c5-cac0922133e0'::uuid,
-       elder_approved_at        = 'YYYY-MM-DD'::timestamptz,
-       cultural_permission_level = 'community-approved',
-       updated_at               = now()
+   set requires_elder_approval = true,
+       elder_approved          = true,
+       elder_approved_by       = 'b59a1f4c-94fd-4805-a2c5-cac0922133e0'::uuid,  -- Kristy Bloomfield
+       elder_approved_at       = now(),
+       updated_at              = now()
   from articles a
  where sc.article_id = a.id
    and sc.site_id = (select id from syndication_sites where slug = 'act-regenerative-studio')
-   and a.slug in ('oonchiumpa-what-happens-when-community-leads');
-*/
+   and a.slug = 'oonchiumpa-what-happens-when-community-leads';
+
+insert into syndication_audit_log (tenant_id, site_id, event_type, event_source, metadata, created_at)
+values (
+  '8891e1a9-92ae-423f-928b-cec602660011'::uuid,
+  (select id from syndication_sites where slug = 'act-regenerative-studio'),
+  'consent_granted',
+  'elder review, recorded on Ben Knight''s statement',
+  jsonb_build_object(
+    'consent_kind',       'ELDER REVIEW. The event_type vocabulary has no elder-review term; consent_granted is the nearest permitted value.',
+    'community',          'Arrernte / Mparntwe (Oonchiumpa)',
+    'approver',           'Kristy Bloomfield',
+    'approver_id',        'b59a1f4c-94fd-4805-a2c5-cac0922133e0',
+    'approver_authority', 'Central Arrernte, Eastern Arrernte, Alyawarra Traditional Owner of Mparntwe; Oonchiumpa co-director',
+    'basis',              'Traditional Owner authority for the Country the story is from satisfies elder review, per wiki/decisions/2026-04-18-oonchiumpa-story-approval.md',
+    'channel',            'verbal, relayed by Ben Knight',
+    'relayed_on',         '2026-08-08',
+    'conversation_date',  'NOT SPECIFIED. elder_approved_at holds the date this was recorded, not the date approval was given.',
+    'witnessed_by',       'Ben Knight',
+    'scope',              'oonchiumpa-what-happens-when-community-leads only; two further articles mentioning Oonchiumpa were deliberately excluded as ACT-authored',
+    'articles',           jsonb_build_array('oonchiumpa-what-happens-when-community-leads')
+  ),
+  now()
+);
 
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-on to #62, which introduced this document. The five asks written on 2026-08-07 all still hold. Four more were found on 2026-08-08 while restoring 107 dead photographs, and together they change which ask matters most.

**The document's "if only one thing gets done" was the dates. It is now elder review** — the only item on the list where being wrong harms somebody rather than reading poorly.

Every figure measured directly against the Empathy Ledger database, not inferred.

## 6. Elder review is recorded nowhere

`syndication_consent` holds 40 rows for this site: 37 approved, every live article covered. That part is in better order than the wiki implies.

But across all 40: `requires_elder_approval` false, `elder_approved` false, `cultural_permission_level` null — while **14 live articles** use Elder, Country, Traditional Owner, custodian, ceremony or sorry business. Titles include *"walking with Elders on Kalkadoon Country"* and *"a day on Quandamooka Country"*.

The columns exist and nothing fills them. `/admin/elder-review` reviews photographs, not articles, so there is no path to fill them.

## 7. The wiki and the database disagree about public-web permission

The org-level approvals in `wiki/decisions/` each list public-internet publication under "What is NOT approved". The database says the opposite, including for the story those records name by title.

That contradiction produced a false alarm on 2026-08-08 and would have produced a **wrong takedown** had it been acted on. The decision records should defer to `syndication_consent` rather than restate it.

## 8. The media gate fails open

`resolveAssetUrl` ends `return gated ?? url` — an unregistered asset ships the raw public URL, which is the form the gate exists to stop emitting. Withholding a photograph is recoverable; shipping an unrevocable one is not.

## 9. Captions, at the real scale

The 123 figure counts article media. The project library is **2,164 images, 118 captioned, 0 credited**, 75 with named people. That is why no photographic surface has been published, and it is not a design backlog.

---

Doc only, 64 → 134 lines. The original five asks are unchanged; today's findings are appended under a dated heading so the provenance of each figure stays clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
