### PR TITLE
Handoff: photographs restored, consent recorded, and the correction that matters

### DIFF
--- a/thoughts/ledgers/CONTINUITY_LEDGER.md
+++ b/thoughts/ledgers/CONTINUITY_LEDGER.md
@@ -1,26 +1,39 @@
 # ACT Regenerative Studio - Continuity Ledger
 
-> Last Updated: 2026-07-29
-> Session: launch hardening, field graph, repo cleanup
-> Full handoff: `thoughts/shared/handoffs/2026-07-29-launch-hardening-and-field-graph.md`
+> Last Updated: 2026-08-08
+> Session: photographs restored, first elder review recorded, tooling trimmed
+> Full handoff: `thoughts/shared/handoffs/2026-08-08-photographs-consent-and-tooling.md`
 
 ## Active Context
 
 ### Current Goals
-- [ ] Editorial work against the Empathy Ledger API — the field graph is the spine,
-      the content is what is thin. See the handoff's last section.
-- [ ] Decide whether EL's taxonomy should be able to express "art AND justice", or
-      whether `src/data/field-assignments.ts` stays the permanent home for that
-      judgement. EL has no art project, so Art can only be populated locally.
-- [ ] Seven articles still attach to no field; reasons recorded in
-      `DELIBERATELY_UNASSIGNED`. Art has 3 pieces and opens the homepage.
-- [ ] `primaryProject` and `themes` are empty on all 29 articles despite existing in
-      the schema; `publishedAt` is a migration artifact (21 of 29 share one timestamp).
+- [ ] **Elder review for eleven weighted articles across four communities.** Kristy
+      Bloomfield's is recorded for Oonchiumpa. Jimmy Frank is in the system and one
+      block away; Palm Island, Quandamooka and Kalkadoon have no approver identity.
+      Run blocks from `docs/integrations/empathy-ledger/record-elder-review.sql`.
+- [ ] **Two builds in Empathy Ledger for consent to be end to end**: an article-level
+      elder review queue (the fields exist, no UI writes them), and consent
+      enforcement on `/api/v1/content-hub/articles/[slug]` (the list route does it,
+      the detail route does not, so a revoke does not stop it serving).
+- [ ] Conversation date for Kristy's approval — `elder_approved_at` currently holds
+      the recording time, and the audit row says so.
+- [ ] 2,164 project photographs: 118 captioned, 0 credited. Unpublishable until that
+      changes. Not a design backlog.
+- [ ] `primaryProject` and `themes` still empty across the corpus; `publishedAt` is
+      still a migration artifact. No date is printed anywhere as a result.
 
-### Recently Shipped (2026-07-29)
-Site is live and verified: 25 launch routes at 200, admin and prototypes gated behind
-`ACT_INTERNAL_TOKEN` (404/401), 0 WCAG AA contrast violations, every link resolving,
-field videos on Supabase, 53 tests green in CI against a real server.
+### CORRECTION carried forward
+An earlier pass raised a consent RED claiming no approval covered public-web
+publication. It was wrong — it read the wiki decision records rather than the
+database. **Empathy Ledger is the system of record; query `syndication_consent`
+first.** The wiki records contradict it and should be made to defer to it.
+
+### Recently Shipped (2026-08-08)
+107 dead photographs → 0 across all 21 live story pages, verified twice. First real
+elder review recorded in Empathy Ledger with provenance. Two false public claims
+removed from /stories. Hero text measurably AA-compliant. CLAUDE.md 20.5K → 9.4K with
+three false facts corrected. Nine skills made findable, three synced. Ten PRs merged
+across two repos; zero open here.
 
 ### Key Patterns Discovered
 - This project uses **Supabase** with pgvector for storage

--- a/thoughts/shared/handoffs/2026-08-08-photographs-consent-and-tooling.md
+++ b/thoughts/shared/handoffs/2026-08-08-photographs-consent-and-tooling.md
@@ -1,0 +1,179 @@
+# Photographs restored, consent recorded, tooling trimmed
+
+**Date:** 2026-08-08
+**Branch:** everything merged to `main`. Zero open PRs in this repo.
+**Supersedes:** `2026-08-08-story-photographs-and-a-consent-red.md`, whose central
+finding was wrong and is corrected below.
+
+---
+
+## Read this first: the correction that matters
+
+An earlier pass in this session raised a **consent RED** claiming no approval
+covered public-web publication of storyteller content. **That was wrong.** It
+was based on reading the wiki decision records, which is where `consent-check`
+says to look, and not the database.
+
+Empathy Ledger is the system of record. `syndication_consent` holds 40 rows for
+the `act-regenerative-studio` site: 37 approved, 38 article-scoped, every live
+article covered by an approved, unrevoked row. Nothing was published without a
+record.
+
+**Rule for next time: query `syndication_consent` before believing the wiki.**
+
+```sql
+select a.slug, sc.status, sc.elder_approved, sc.revoked_at
+from articles a
+left join syndication_consent sc on sc.article_id = a.id
+ and sc.site_id = (select id from syndication_sites where slug='act-regenerative-studio')
+where a.syndication_enabled and a.status='published';
+```
+
+---
+
+## What shipped
+
+Ten PRs across two repos, all merged, deployed and verified live.
+
+### Photographs: 107 dead → 0
+
+Every photograph on all 21 live story pages resolves. Verified twice by
+`npm run check:media` (baseline 0) and once by direct inspection of production
+HTML.
+
+Two changes closed it:
+
+1. **A migration in Empathy Ledger** rewrote 244 article-body URLs off the
+   retired public bucket onto the gated `/api/media/<id>/file` route, across 40
+   articles. Backup table `articles_content_backup_20260807` still exists.
+   Verified same-article: "The Spirit Must Be Strong" carried 19 raw
+   public-storage URLs before and 19 gated ones after.
+2. **This repo's sync stopped taking photographs from the content-hub detail
+   route**, which does not apply the consent gate, in favour of the list route,
+   which does.
+
+Empathy Ledger PR #493 also closed the underlying hole: `articles/[slug]`
+called `resolveAssetUrl` with two arguments instead of three and never built the
+gate map, so every photograph it returned was a raw, unrevocable URL.
+
+### Consent: the first real elder review recorded
+
+Kristy Bloomfield's elder review is on the consent row for
+`oonchiumpa-what-happens-when-community-leads`, attributed by id, provenance in
+audit row `a0cea170`.
+
+Scope is deliberately one article. *History's Wounds* and *JusticeHub: A
+Platform* mention Oonchiumpa but are ACT-authored pieces, and were excluded
+rather than swept in by name match.
+
+`elder_approved_at` holds the moment of **recording, not the conversation**. The
+date was never given. The audit row says so.
+
+### Site corrections
+
+- `/stories` no longer claims "One place. Many voices." above 21 pieces with one
+  byline, nor that each story keeps "its people and its permissions" when the
+  feed carries no per-story consent record.
+- The article reader stopped printing a date derived from a migration timestamp.
+- Hero text measured by sampling rendered pixels: the clay-gold "All stories"
+  link ran 1.58–4.18 against a 4.5 requirement and moved onto a solid surface.
+  Scrim 25/45/80 → 30/60/85.
+
+### Tooling
+
+```
+CLAUDE.md            20,545 → 9,384 bytes, three false facts corrected
+skills with no description   9 → 0
+dangling symlinks (live)     3 → 0
+stale project skills         3 synced, ~1,050 lines lighter
+local MCP servers            7 → 4
+```
+
+---
+
+## Next steps, in priority order
+
+### 1. Elder review for the remaining eleven articles
+
+Four communities, none recorded. `docs/integrations/empathy-ledger/record-elder-review.sql`
+has a block per community; run only the ones with an actual approval behind them.
+
+| community | articles | approver |
+| --- | --- | --- |
+| Warumungu / Tennant Creek | 2 | Jimmy Frank is in the system (`dda39576-…`) |
+| Bwgcolman / Palm Island | 1 | none identified |
+| Quandamooka | 1 | none identified |
+| Kalkadoon | 1 | none identified |
+| not community-specific | 6 | may need none |
+
+Also outstanding: the **conversation date** for Kristy's approval, and whether
+her approval extends to the two ACT-authored pieces that mention Oonchiumpa.
+
+### 2. Two builds in Empathy Ledger, for "end to end" to be true
+
+- **An article-level elder review queue.** `/admin/elder-review` reviews
+  photographs and writes to `media_assets`. Nothing writes the article-level
+  fields, so every approval has to arrive as hand-written SQL. Three-quarters of
+  a feature: columns on the consent row, no vocabulary in the audit log, no UI.
+- **Consent enforcement on the detail route.** The list route joins
+  `syndication_consent`, respects `consent_enforced` and fails closed. The
+  `[slug]` route does neither, so a revoke in the admin UI does not stop it
+  serving.
+
+### 3. Smaller, still open
+
+- **The media gate fails open.** `resolveAssetUrl` ends `return gated ?? url`, so
+  an unregistered asset ships raw. Flagged on EL #493.
+- **The wiki decision records contradict the database** and should defer to it.
+- **2,164 project photographs**: 118 captioned, 0 credited, 75 with named people.
+  Unpublishable until that changes; not a design backlog.
+- **The at-rest URL rewrite hardcoded `empathyledger.com`** into stored content
+  where the app uses `NEXT_PUBLIC_APP_URL`. Reversible from the backup table.
+- **claude.ai connectors** — Adobe, Canva, Miro are ~110 unused tool definitions.
+  Only reachable from claude.ai settings.
+- **`ACT_What_the_Road_Corrects_Website_Release (1).docx`** still untracked in the
+  repo root. It is the essay the homepage speaks in. No decision on where it goes.
+
+---
+
+## Traps worth not rediscovering
+
+- **The baked snapshots in `src/data/*.generated.json` are a stale fallback**, not
+  the truth. Production reads live. Measure rendered pages, never the JSON.
+- **That storage endpoint rejects `HEAD`** for everything. Probe with `GET` and
+  check `content-type` starts with `image/`.
+- **De-duping media probes by URL silently drops roles** when one photograph is
+  hero, gallery and body at once. It hid two dead heroes.
+- **A photograph that appears to work may be a Cloudflare cache hit**
+  (`max-age=3600`). Check `cf-cache-status`: HIT means the origin was never asked.
+- **Clay-gold `#CFA16B` (luminance 0.397) can never clear AA over an arbitrary
+  photograph** at any scrim opacity. Small gold labels belong on solid surfaces.
+- **`check-contrast.mjs` cannot see text over media**, by design. Measure by
+  sampling rendered pixels: Playwright screenshot with the text layer hidden,
+  decode with `sharp`, worst-case luminance in each text rect. Scripts must live
+  in the repo root or the playwright/sharp imports do not resolve.
+- **`cultural_permission_level` allows only** `public | community | restricted |
+  sacred`. It describes the material's sensitivity tier, not who approved it.
+- **`syndication_audit_log.event_type` has no elder-review value.** Nine permitted
+  values, none of them this. `consent_granted` plus `consent_kind` in metadata is
+  the current workaround.
+- **`npm run db:types` does not exist**, despite older notes. Use the Supabase MCP
+  or CLI.
+- **Never `git commit -am` in this repo.** Modified pages import untracked new
+  files; curate the add.
+- **Restart the dev server after editing `config/launch-redirects.cjs`.**
+
+---
+
+## Gates
+
+- `npm run check:media` — rendered production story pages, **baseline 0**. Retries
+  non-image responses twice, because the gated route 302s across two hosts and a
+  429 from either was making it flaky.
+- `npm run check:consent` — blocks a commit touching the nine paths that change
+  what community content is public. Pass with
+  `CONSENT_CHECKED="<one line>" git commit …`. Install with `npm run hooks:install`.
+- `check-contrast.mjs` — resolves one story article at run time so
+  `/stories/[slug]` is covered. 26 routes, no violations.
+- `npx tsc --noEmit && npm run test` — the fast gate. `npm run build` runs the EL
+  and Notion syncs first and hits the network.


### PR DESCRIPTION
Session record for 2026-08-08 plus a continuity-ledger update, so the next session starts from what is true.

## The correction leads, deliberately

A consent **RED** was raised earlier today claiming no approval covered public-web publication of storyteller content. **It was wrong.** It read the wiki decision records — where `consent-check` says to look — and not the database.

Empathy Ledger is the system of record: 40 rows for this site, 37 approved, every live article covered. Reading only the wiki would have caused a wrong takedown. The handoff opens with that rule and the query to run.

## What shipped

- **107 dead photographs → 0** across all 21 live story pages, verified twice by gate and once by direct HTML inspection
- **First real elder review recorded** with provenance (Kristy Bloomfield, audit row `a0cea170`), scoped to one article and no wider
- Two false public claims removed from `/stories`; the fabricated date gone from the article reader
- Hero text measurably AA-compliant, by sampling rendered pixels rather than guessing
- CLAUDE.md 20,545 → 9,384 bytes with three false facts corrected
- Nine skills made findable, three synced ~1,050 lines lighter, MCP servers 7 → 4

## Next steps, ordered by what blocks the work

1. **Elder review for eleven articles across four communities** — with a table of who can approve what and which identities are missing from the system
2. **Two builds for consent to be end to end**: an article-level elder review queue (fields exist, no UI writes them) and consent enforcement on the detail API route (a revoke currently doesn't stop it serving)
3. Smaller: the media gate fails open, the wiki should defer to the database, 2,164 photographs remain uncaptioned and uncredited

## Eleven traps recorded

Each one cost time today. The baked snapshots are a stale fallback, not the truth. That storage endpoint rejects `HEAD`. A photograph that appears to work may be a Cloudflare cache hit. Clay-gold can't clear AA over an arbitrary photograph at any scrim opacity. `cultural_permission_level` is a sensitivity tier, not an approval state. `npm run db:types` doesn't exist.

Docs only. Supersedes the earlier handoff from this morning, whose central finding was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
