### PR TITLE
Field Notes 01: give the essay the homepage speaks in a tracked home

### DIFF
--- a/compendium/04-story/what-the-road-corrects.md
+++ b/compendium/04-story/what-the-road-corrects.md
@@ -1,0 +1,264 @@
+---
+title: What the Road Corrects
+slug: what-the-road-corrects
+series: Field Notes 01
+author: Benjamin Knight
+excerpt: "On useful things, the work that stays, and the people we hope to find"
+date: 2026-08-07
+status: published
+last_updated: 2026-08-08
+---
+
+# What the Road Corrects
+
+**A Curious Tractor · Field Notes 01**
+
+*On useful things, the work that stays, and the people we hope to find*
+
+Benjamin Knight, 7 August 2026
+
+> **Provenance.** Filed verbatim from `ACT_What_the_Road_Corrects_Website_Release.docx`,
+> released 7 August 2026. The original document is in `Writing/`, which is not tracked.
+> This essay is the source the homepage hero copy draws on
+> (`src/app/prototypes/living-field/prototype.tsx`); it is not itself a route on the site.
+> Only pandoc's escaped apostrophes were changed in conversion. The prose is unedited.
+
+Before we left, I built a system for the road.
+
+It contained the distances, the fuel, the beds, the people we hoped to see and the people we had no right to see without being invited. There were dates for returning photographs. There were consent checks, permits, warm introductions and alternate routes in case the first route closed. I made a place for what we would collect and another for what we would owe. I gave each day a purpose.
+
+The system knew where we were going.
+
+In my out-of-office message I wrote that the trip was about beds, stories, justice and a little bit of connection with my amazing family.
+
+I read it again after it had begun replying to people on my behalf.
+
+Family had come last.
+
+I left the sentence as it was.
+
+We packed the car.
+
+●
+
+We began A Curious Tractor by putting the wrong thing first.
+
+We began with motion. Nic and I liked ideas that could get up and walk around. We had little patience for the kind that stayed in a document, immaculate and unlived. Nic had helped put washing machines and dryers in the back of a van and driven them to parks where people were sleeping rough. The machines washed clothes. Chairs appeared beside them. People sat down. Time behaved differently there.
+
+The machine was useful, which mattered. Its usefulness also gave people a reason to remain near one another without having to pretend that conversation was the service. Nic understood this before we had language for it. Put an ordinary thing in the right place and a room can open around it, even outside.
+
+I came by another road. I worked in youth justice, community programs and places where institutions had already decided what a person meant. In the Lower Gulf I ran alcohol and violence programs written somewhere else by people who would never sit in the rooms where the programs landed. The activities filled eight hours. The food and the yarning did the work. I used to tear through the workbook to reach the part of the day when everyone could stop performing.
+
+Years later, I would write that the programs were theatre and the yarning was church. I still believe it. I also know how easily a line like that can make an old failure sound wise. At the time I was young, employed by Corrective Services, carrying a government clipboard and relieved whenever people were generous enough to rescue the day from what I had brought into it.
+
+Photography became another way for me to enter. A camera can open a door. It can also make the person holding it feel that the open door belongs to them. The photograph leaves. It appears in a report, on a website, in a funding room. The photographer is thanked. The person in the image may never see it.
+
+I did not understand the full weight of that for a long time. I only knew that taking a picture sometimes felt close to listening and sometimes felt like the opposite.
+
+When Nic and I started ACT, we wrote brightly about ideas, seeds and action. We liked the tractor because it was practical and slightly ridiculous. It belonged outside. It suggested work with weight behind it. We imagined ourselves beside people, helping an idea become real, then giving it back.
+
+We were sincere. We were also in love with our own momentum.
+
+Curiosity sounds harmless when you are the curious one. From the other side it can feel like another person arriving with questions. Action has the warmth of virtue until the action is premature. Even giving something back can be a strange promise if you have not asked who owned it before you touched it.
+
+The first years of ACT were full of yes. Projects accumulated faster than any philosophy could hold them. A justice platform. Beds. Washing machines. Story circles. A farm. A photo kiosk. An artwork made from a shipping container. Civic data. Workshops. Kitchens. Gardens. Software. We moved between them with the conviction that the connection would eventually reveal itself.
+
+Sometimes it did. Sometimes exhaustion looked like commitment because both kept us awake at night.
+
+The road has been correcting us ever since.
+
+●
+
+In Mparntwe, in forty-three-degree heat, I walked past police checking identification outside shops. Houses sat behind high fences and coils of wire. Young people wore tracking bracelets and had found ways to make even those objects carry belonging.
+
+I had been welcomed onto Country. I travelled through town with Oonchiumpa workers. They knew which camp to enter, who needed collecting, which young person had disappeared from the official version of the day, and where they might actually be found.
+
+Small things changed in their presence. A meal. A lift. A bed made. A young person rapping in the back seat. None of it looked like the language used to announce a program. It looked like people knowing one another.
+
+I kept asking myself what my place was. This can be an honest question. It can also become a comfortable one, because a visitor may spend so much time examining his position that he remains the subject of every room.
+
+Oonchiumpa did not need my uncertainty. There were young people to pick up.
+
+So we followed.
+
+Later, young people assembled Stretch Beds with the Oonchiumpa team. The bed is deliberately plain: canvas, two steel poles and legs made from recycled plastic. It comes apart. It travels flat. You do not need a toolbox to put it together.
+
+One young man turned the pieces in his hands and made one. The poles passed through the canvas. The legs clipped into place. He sat on the finished bed and talked about making more.
+
+The moment mattered. It was not permission to turn his morning into proof of a national model.
+
+We have often been too quick to make a system from a beautiful moment.
+
+The bed went out on the road. The relationship had been travelling for years.
+
+●
+
+Beds later moved from Alice Springs toward Utopia Homelands with Oonchiumpa. Local people opened the route. They knew the families. They knew where the road changed and how to approach a house without making the arrival feel like an inspection.
+
+In the yards were the things people had already made: car trays held on bricks, mattresses resting on tyres, foam laid across plywood. The households did not lack ingenuity. They lacked the ordinary goods that other households buy without having to become ingenious first.
+
+The bed had been through prototypes and corrections by then. It needed to rise from the ground without making an older person fight it every morning. It needed to survive dust, heat, children, visitors and the movement of a household that did not resemble the diagram in a product designer's head. It had to be washable. Parts had to be replaceable. Freight could not cost more than the thing.
+
+People tested it with their bodies. They sat, lay down, pulled at the canvas and told us what they thought. Comfortable. Easy. Too low. Good for outside. Make more. The useful sentences were usually short.
+
+We had spent years learning to describe the bed. The road kept finding people who could describe it in two words.
+
+This is where Goods on Country begins, but the bed is not the whole of it. A useful object arrives. Then the harder question begins. What stays after the truck leaves?
+
+If only the bed stays, we have delivered a product. If the skills, wages, machinery, contracts, knowledge, margin and decisions remain too, something else becomes possible. The people doing the work can decide what gets made next. The enterprise can belong nearer to the place that carries it. Our role can become smaller without the work becoming smaller.
+
+We have started to use a plain test: what arrived, what left, and what stayed?
+
+It is not a test Goods always passes. It is the test we want the work to answer.
+
+●
+
+I took photographs on the journey. Each time, trust was lent to me for a particular use. It was not a general licence issued because ACT had arrived with good intentions. Some images could travel. Some could travel only after they came home. Some moments belonged where they happened.
+
+This is where the Empathy Ledger began to make sense to me, though the idea had been growing for years. A ledger usually records what has been received. Ours needed to record what remained owed: a print, a name spelled correctly, another conversation, a changed consent, a story returned in the form its teller could use.
+
+The technology was the easy part to imagine. The hard part was accepting that a good system must sometimes stop a story from moving.
+
+On this trip, we carried a small printer. Where we could, the photograph was printed before we left. One copy went to the person. Another went to the community organisation if that was wanted. Anything unfinished went onto the owes list with a name beside it.
+
+The paper came out slowly. The colours settled. Someone held the image by its edges.
+
+For a moment, the story had travelled no farther than the hands it came from.
+
+On Palm Island, a conversation about storm damage turned toward what children might need. The institutional story of a storm prefers damage. Damage is countable. A photograph of damage behaves well in an appeal. The conversation had other plans.
+
+Storm Stories became a way of keeping those accounts on the island, with a kiosk and a local server. We wanted the people who told the stories to remain connected to what happened next. We wanted a photograph to come back. We wanted consent to stay alive after the form was signed.
+
+Wanting this did not make it true. The promise has to survive staff changes, broken equipment, funding periods, software updates and our own tendency to move toward the next urgent thing.
+
+The road remembers every return we said we would make.
+
+●
+
+JusticeHub grew from the same unease. Across youth justice, I kept meeting people who had built working answers in places treated only as evidence of failure. Their knowledge stayed local while policy travelled nationally. A program could change a life and still disappear because it was not visible to the right institution at the right time.
+
+I thought a platform could help.
+
+I still think it can. I am less certain about the posture of the platform.
+
+A map is seductive. Once every project appears as a point, the person who owns the map can begin to feel they understand the Country beneath it. Evidence can behave the same way. It gathers in the centre. Communities are asked to explain themselves again. Their experience becomes a case study, then a category, then a number that returns wearing somebody else's logo.
+
+JusticeHub must connect without becoming the place from which justice appears to come. Empathy Ledger must let a story travel without carrying its authority away. CONTAINED, our artwork built from a shipping container, must do more than give an audience a strong feeling about prisons. A person can walk through an exhibition, feel shaken and still leave the system exactly as they found it.
+
+These projects sound different when they are presented separately. On the road they keep meeting the same question: what moves, what stays, and who decides?
+
+We have tried to answer with protocols and governance. We have built consent fields, community servers, ownership models, asset registers and rules for stories going home first. That work is necessary. None of it lets us stop paying attention.
+
+A rule cannot tell you whether to lift the camera in a particular silence.
+
+ACT is not a First Nations organisation and does not speak as one. When we are invited into work with First Nations communities, our responsibility is to follow community authority, be clear about what we hold, and accept correction, refusal and silence as part of the work. A relationship is not consent in perpetuity. A good history together does not turn the next visit into an entitlement.
+
+●
+
+Nic and I often stand on different sides of this.
+
+I reach for the map. I want the ledger to remember, the evidence to connect and the system to survive us. I worry about good work disappearing because nobody recorded how it happened.
+
+Nic reaches for the room. He notices the table, the kettle, the thing that needs fixing and the person standing alone. He distrusts machinery that makes a relationship legible by making it smaller. He worries that the record will begin to replace the life it was meant to serve.
+
+Both worries are justified. Both can become vanity.
+
+Without a record, people and communities are repeatedly asked to begin again. With the wrong record, they are kept forever inside the story an organisation needed them to tell.
+
+ACT lives inside that argument.
+
+The Harvest at Witta has made the argument physical. A garden needs attention after the workshop ends. Food must be ordered, cooked and cleaned away. Rain changes the day. A guest becomes a host. The romantic account of a gathering leaves before the plates are washed. The place remains.
+
+Black Cockatoo Valley, the farm beneath it, does not permit us to live entirely in ideas. Fences fail. Weeds return. A place remembers whether you came back to care for it. It has taught us that hosting is work and that belonging is made through repeated acts, not declared in a project description.
+
+We once spoke about ACT as Listen, Curiosity, Action and Art, a sequence that could move an idea toward change. The road has made a mess of the sequence.
+
+Listening does not finish before curiosity begins. You listen again after the prototype fails, after a person withdraws permission, after the funding changes the relationship. Curiosity needs a boundary or it becomes appetite. Action may mean driving all day. It may mean waiting outside a closed door and then leaving. Art begins early, in how we notice, and arrives late, after everyone represented in it has had the chance to disagree.
+
+There may be no philosophy beyond coming close enough to be corrected, then returning to find out whether the relationship still holds.
+
+●
+
+Things come apart.
+
+A bolt loosens. A printer jams. A staff member leaves with the password still in their head. The grant ends. A relationship is reduced to a line in a handover document. Equipment sits behind a locked door. A story keeps circulating after the person who told it has changed their mind.
+
+There is a name for this drift. Entropy. Energy disperses. Attention moves. The shape that people worked hard to make begins to loosen.
+
+It happens to every project, including ours. It is not always failure. People leave, needs change and useful things wear out. The mistake is to build as though the first burst of energy will hold everything together forever.
+
+ACT cannot prevent things from coming apart. Our work is to leave behind ways they can be renewed. Someone local knows how to repair the bed. The order book can pay a wage. The story carries its consent with it. The evidence can be corrected. The machinery has an owner. The next person can see what was promised. There is money for maintenance, not only for launch day. There is a way to gather again.
+
+This is why we care about the enterprise around the bed, not only the bed. It is why Empathy Ledger keeps an owes list. It is why JusticeHub must show the people and relationships beneath the program name. It is why the Harvest is a place, not an event series. It is why art belongs in the method. Facts tell us that something is coming loose. Art can make us care enough to return.
+
+We are not designing permanence. Nothing living stays still. We are trying to design for renewal.
+
+●
+
+The family questions on a long drive are plain. How far? Where are we sleeping? Are you still working? Why are we stopping here?
+
+They puncture the grand account.
+
+To a child, a bed in the back of a vehicle may be a place to climb, something that rattles, an obstruction between one stop and the next. The road is not an organisational metaphor. It is hours in a seat. Food wrappers. Missing socks. Petrol. A parent looking at a screen when the Country outside the window is asking for attention.
+
+I have spent years trying to bring my whole self into the work. This journey has made me wonder how often the work has been invited to bring its whole self into my family.
+
+There are clean ways to describe the trip for accounting. Business. Private. Mixed. Each day has a classification. The categories matter. They do not describe what it feels like when the same hour contains a family holiday, a promise to return photographs, a phone call about money and a road opened by people whose trust cannot be entered as an expense.
+
+My family are not evidence that ACT is humane. They are not the soft edge of the story. They are living inside the consequences of what Nic and I choose to build.
+
+We have often spoken as though exhaustion proved proximity to the work. As though carrying more relationships made us more faithful to them. As though rest belonged to some later version of the company, after the urgent things were done.
+
+The urgent things reproduce at night.
+
+If ACT cannot make room for family, sleep, clear decisions and money that arrives when it should, then its philosophy fails before it reaches anyone else. Care cannot be financed indefinitely by the private depletion of the people performing it. A beautiful project can still leave a mess in somebody's kitchen.
+
+The road makes this difficult to disguise. Everyone is in the same car.
+
+●
+
+I began this essay on the road. I am finishing it on the day my out-of-office message said I would return.
+
+The journey has not delivered a neat definition of ACT. It has made some things harder to avoid.
+
+We are here because useful work often arrives without the relationship needed to change it, while good relationships are left without the machinery, money or memory needed to continue. ACT works in the space between them. We make ordinary things, build platforms, grow food, create art and follow evidence. The form changes. The promise should not.
+
+The work must become more useful to the people carrying it and less dependent on us.
+
+That is what we mean by beautiful obsolescence. It is easy to admire as a phrase. In practice it means giving up control, income, authorship and the pleasure of being necessary. It means a community owns the machine and the margin. A storyteller can close the gate. A local organisation holds the relationship. A platform becomes shared infrastructure. ACT may remain nearby, but it is no longer in the middle.
+
+We do not always know how to do this. Sometimes we have kept too much. Sometimes we have undercharged because the relationship felt too important to price, then asked our families and our future selves to carry the difference. Sometimes we have made the work legible to a funder before making sure it was useful to the people living with it. Sometimes we have confused being busy with being wanted.
+
+Those habits have to end.
+
+One of the next experiments is GrantScope. A list of grants is not enough. We want to understand how money actually moves, who it reaches, who is repeatedly missed and what the formal record cannot explain. Software can keep the public information current. Empathy Ledger can hold the human account beside it, with permission. The purpose of the automation is not to remove people from the work. It is to reduce the administration that keeps people from the work.
+
+We have relationships in Kununurra, Mparntwe and Brisbane that may allow a focused youth justice pilot to begin. A relationship is not a pilot agreement. Each place has to decide whether the work is useful, what it is allowed to know, and who should hold it. The funders involved will need to pay properly for the work of learning, not only for a dashboard at the end.
+
+Goods is asking a similarly practical question. Who will buy enough beds for a local order book to exist before a community is asked to carry a factory? Which money should pay for the machinery because it can be repaid? Which money should pay for mentoring, training and cultural governance because it should not be forced to produce a financial return? Who will fund the first proof honestly, including the parts that may not work?
+
+These are not side questions. They decide whether value remains in community or quietly returns to the centre.
+
+●
+
+So this is also an invitation, though not a general one.
+
+We would like to find people already holding real work. Community leaders and community-controlled organisations with a specific problem, an idea or a useful thing they want to test, and the authority to tell us no. Buyers and procurement people willing to place real orders, because a promise of demand does not pay a wage. Funders and investors who can tell the difference between plant, people and proof, and who understand that each needs a different kind of money.
+
+We would like to find makers, artists, engineers, technologists, growers, storytellers and researchers who can work with what is present, document what is owed and leave the keys with somebody else. We need people who are good at maintenance, handover and the unglamorous middle. We need hosts who know a place well enough to say whether we should enter. We need people willing to correct the premise, not only improve the proposal.
+
+Most of all, we would like to meet the people who may one day hold the work without ACT.
+
+If that is you, do not send us a polished brief. Tell us what is happening. Tell us who is already carrying it. Tell us what must not be taken. Tell us what would need to remain after we leave.
+
+That is enough to begin.
+
+The map is still open. The route line is bright and certain. It passes through places that are not empty space between our appointments. Every road is already inside somebody's Country, memory and ordinary day.
+
+We will get some things wrong.
+
+Today the system says the journey is over.
+
+The owes list says otherwise.
+
+That is where we begin.


### PR DESCRIPTION
"What the Road Corrects" was released on 7 August as a Word document and had been sitting untracked in the repo root. The homepage hero copy is drawn from it and cites it by name in `prototype.tsx`, so the source of what the site says was the one thing the repo could not see.

Filed at `compendium/04-story/what-the-road-corrects.md`.

**Why that path.** `compendium/04-story/vignettes/` is scanned recursively by `get-project-vignettes.ts:62`, so anything dropped there becomes site content. The root of `04-story` is read by no route. This is a filing decision, not a publishing one, and the frontmatter carries no `website_path` because there is no route to name.

**The prose is unedited.** Conversion changed four escaped apostrophes and nothing else. The title block moved into the header, which accounts for the entire 33-word difference against the original (3808 -> 3775). The essay already carried no em-dashes, so it passed the voice rule as written.

The `.docx` original moved to `Writing/`, which is gitignored and already holds other essays. The repo tracks no binaries anywhere and this does not start.

**Publishing stays open.** Field Notes 01 implies a series and the document is stamped WEBSITE RELEASE, but the site has no essay route, and building one is a public-surface change wanting its own voice and contrast pass.

Gates: `check:copy` and `check:consent` pass; the pre-commit hook re-ran `check:copy` clean. No files under `src/`, `config/` or `public/`, so site behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)