### PR TITLE
handoff: consent enforcement closed, and one migration left loaded

### DIFF
--- a/docs/integrations/empathy-ledger/featured-image-backfill-2026-08-08.sql
+++ b/docs/integrations/empathy-ledger/featured-image-backfill-2026-08-08.sql
@@ -1,0 +1,95 @@
+-- Register the 34 unregistered featured images so they serve through the gated
+-- route, and point each article at its new asset.
+--
+-- Run against the Empathy Ledger project: yvnuayzslukamizrlhwb
+-- (Supabase dashboard -> SQL editor). Safe to re-run: both statements are
+-- idempotent.
+--
+--
+-- WHY THESE 34 ARE BROKEN RIGHT NOW
+--
+-- Their featured image lives in articles.import_metadata->>'featuredImageUrl'
+-- as a raw URL under /storage/v1/object/public/media/. The `media` bucket is no
+-- longer public, so that URL returns 400 NoSuchBucket. The objects themselves
+-- are all still in the bucket (verified: 34 of 34 present in storage.objects).
+-- They are simply unregistered in media_assets, so nothing can sign a URL for
+-- them, and the article has no featured_image_id to fall back to.
+--
+-- All 34 are consumed by JusticeHub. None are on the ACT site.
+--
+--
+-- WHAT THIS ASSERTS
+--
+-- requires_consent = false, visibility = 'public'. Same shape the earlier
+-- `ungoverned-public-media-backfill-2026-07-30` used for this same class of
+-- file, and it is what makes evaluateMediaGate() return 'publishable':
+--   visibility='public' AND (requires_consent=false OR consent_obtained
+--   OR consent_granted OR contained_consent)
+--
+-- Ben confirmed 2026-08-08 that these images carry no people and are cleared
+-- for use. alt_text is provisional and flagged as such. elder_review_status
+-- stays 'unreviewed', which the gate treats as neutral (only
+-- 'sacred_no_publish' is a hard no).
+
+
+-- 1. Register the assets.
+with parsed as (
+  select a.slug,
+         split_part(split_part(a.import_metadata->>'featuredImageUrl','/storage/v1/object/public/media/',2),'?',1) as sp
+  from articles a
+  where a.status='published' and a.featured_image_id is null
+    and a.import_metadata->>'featuredImageUrl' like '%/storage/v1/object/public/media/%'
+), unreg as (
+  select distinct p.sp
+  from parsed p
+  where not exists (select 1 from media_assets ma where ma.storage_path = p.sp)
+)
+insert into media_assets (
+  original_filename, file_size, file_type, media_type, mime_type,
+  storage_bucket, storage_path, tenant_id, uploader_id,
+  privacy_level, visibility, requires_consent, status,
+  alt_text, metadata
+)
+select
+  regexp_replace(u.sp, '^.*/', ''),
+  coalesce((o.metadata->>'size')::bigint, 0),
+  'image', 'image',
+  coalesce(o.metadata->>'mimetype', 'image/jpeg'),
+  'media', u.sp,
+  'bf17d0a9-2b12-4e4a-982e-09a8b1952ec6'::uuid,   -- same tenant as the 2026-07-30 backfill
+  'd0a162d2-282e-4653-9d12-aa934c9dfa4e'::uuid,   -- same backfill operator
+  'public', 'public', false, 'active',
+  'Undescribed image: ' || regexp_replace(regexp_replace(u.sp,'^.*/',''), '\.[^.]+$', ''),
+  jsonb_build_object(
+    'bucket','media',
+    'backfill','featured-image-backfill-2026-08-08',
+    'reviewed', false,
+    'tenant_source','referenced_by_published_writing',
+    'alt_text_provisional', true,
+    'uploader_is_backfill_operator', true
+  )
+from unreg u
+join storage.objects o on o.bucket_id='media' and o.name = u.sp
+returning id, storage_path;
+
+
+-- 2. Point each article at its newly registered asset.
+--    The detail route prefers featured_image_id over the raw import_metadata
+--    URL, so this is what actually fixes the rendered image.
+update articles a
+set featured_image_id = ma.id
+from media_assets ma
+where a.status='published'
+  and a.featured_image_id is null
+  and a.import_metadata->>'featuredImageUrl' like '%/storage/v1/object/public/media/%'
+  and ma.storage_path = split_part(
+        split_part(a.import_metadata->>'featuredImageUrl','/storage/v1/object/public/media/',2), '?', 1);
+
+
+-- 3. Verify: expect still_broken = 0, now_wired = 34.
+select
+  count(*) filter (where a.featured_image_id is null)     as still_broken,
+  count(*) filter (where a.featured_image_id is not null) as now_wired
+from articles a
+where a.status='published'
+  and a.import_metadata->>'featuredImageUrl' like '%/storage/v1/object/public/media/%';

--- a/docs/integrations/empathy-ledger/host-relative-media-urls-2026-08-08.sql
+++ b/docs/integrations/empathy-ledger/host-relative-media-urls-2026-08-08.sql
@@ -1,0 +1,84 @@
+-- Make stored article bodies host-relative, so a domain move does not mean
+-- rewriting stored content.
+--
+-- Run against the Empathy Ledger project: yvnuayzslukamizrlhwb
+--
+--
+-- RUN THIS ONLY AFTER THE CODE IS DEPLOYED TO PRODUCTION
+--
+-- The order is the opposite of the featured-image backfill, and it is not
+-- optional. The read path has to absolutize before the data becomes relative:
+--
+--   code first, then data -> consumers keep receiving absolute URLs throughout
+--   data first, then code -> every consumer receives `/api/media/...`, resolves
+--                            it against its OWN domain, and 404s. That is
+--                            exactly the JusticeHub eight-broken-images bug
+--                            recorded in serve-absolutize.test.ts.
+--
+-- The code change is a no-op against today's data (absolute URLs pass through
+-- untouched), so there is no rush between the two steps. Verify the deploy is
+-- live, then run this.
+--
+--
+-- WHAT IT CHANGES
+--
+-- 244 URLs across 40 published articles, written by the 2026-08-07 migration as
+-- `https://empathyledger.com/api/media/<id>/file`. After this they are stored
+-- `/api/media/<id>/file` and absolutized per-environment on read by
+-- absolutizeServeUrlsInHtml(), which is the convention absolutizeServeUrl()
+-- already documents for the catalog's avatar and display URLs.
+--
+-- Only attribute-initial occurrences are rewritten, matching the code exactly,
+-- so prose that happens to mention the URL is left alone.
+--
+-- Reversible: articles_content_backup_20260807 still exists, and the reverse
+-- rewrite is the same statement with the two arguments swapped.
+
+
+-- 1. Count first. Expect 40 articles / 244 occurrences before, 0 after.
+select
+  count(*) filter (where content like '%"https://empathyledger.com/api/media/%')  as articles_absolute,
+  coalesce(sum((select count(*) from regexp_matches(content,'"https://empathyledger\.com/api/media/','g'))), 0) as occurrences_absolute,
+  count(*) filter (where content like '%"/api/media/%')                            as articles_relative
+from articles
+where status='published';
+
+
+-- 2. Rewrite. Double-quoted and single-quoted attribute values both.
+update articles
+set content = replace(
+      replace(content, '"https://empathyledger.com/api/media/', '"/api/media/'),
+      '''https://empathyledger.com/api/media/', '''/api/media/'
+    ),
+    updated_at = now()
+where status='published'
+  and (content like '%"https://empathyledger.com/api/media/%'
+    or content like '%''https://empathyledger.com/api/media/%');
+
+
+-- 3. Verify: expect articles_absolute = 0, occurrences_absolute = 0,
+--    articles_relative = 40.
+select
+  count(*) filter (where content like '%"https://empathyledger.com/api/media/%')  as articles_absolute,
+  coalesce(sum((select count(*) from regexp_matches(content,'"https://empathyledger\.com/api/media/','g'))), 0) as occurrences_absolute,
+  count(*) filter (where content like '%"/api/media/%')                            as articles_relative
+from articles
+where status='published';
+
+
+-- 4. Then confirm on the wire, not in the table. A consumer must still receive
+--    an ABSOLUTE url:
+--
+--    curl -s -H "X-API-Key: $EMPATHY_LEDGER_API_KEY" \
+--      "https://empathyledger.com/api/v1/content-hub/articles/the-spirit-must-be-strong" \
+--      | grep -o 'src="[^"]*/api/media/[^"]*"' | head -3
+--
+--    Expect https://empathyledger.com/api/media/<id>/file, NOT /api/media/<id>/file.
+--    And re-run the ACT gate, which renders the real pages: npm run check:media
+--    (baseline 0 dead across 21 story pages).
+
+
+-- NOT IN SCOPE, recorded so it is not lost: 6 rows in `stories` carry the same
+-- hardcoded host in their content, served by /api/v1/content-hub/stories/[id],
+-- which this change does not touch. Separate table, separate surface, and
+-- leaving them absolute keeps their behaviour exactly as it is today.

--- a/thoughts/ledgers/CONTINUITY_LEDGER.md
+++ b/thoughts/ledgers/CONTINUITY_LEDGER.md
@@ -6,23 +6,30 @@
 
 ## Active Context
 
-### DO THIS FIRST — one migration is loaded and not run
+### DO THIS FIRST — the migration was run, broke the site, and is reverted
 `docs/integrations/empathy-ledger/host-relative-media-urls-2026-08-08.sql`
 
-244 URLs across 40 articles, rewriting stored bodies to host-relative. Its
-prerequisite is **met**: PR #501 is merged and deployed, confirmed on the wire
-(production returns 5 absolute `/api/media` URLs, 0 host-relative).
+Run 2026-08-08. **It took the hero off 13 of 21 ACT story pages.** Reverted
+immediately; data is byte-identical to before and `check:media` is back to
+200 live / 0 dead.
 
-**Code first, data second — not the reverse.** Migrating before the read path
-absolutizes would emit host-relative URLs to every partner, which resolve
-against the partner's own domain and 404. That is the JusticeHub
-eight-broken-images bug recorded in `src/lib/media/serve-absolutize.test.ts`.
+**Do not run it again until EL PR #504 is merged AND deployed.** #501
+absolutized the body after `extractFirstImage` had already read the stored form,
+so the hero came out `/api/media/...` and `resolveAssetUrl` resolved it against
+the article's original source site — a valid URL to a host that never had the
+file. #504 resolves the body before anything reads it, in both routes, and gives
+`resolveAssetUrl` an explicit `/api/media/` branch.
 
-After: confirm consumers still receive absolute URLs, then `npm run check:media`
-(baseline 0 dead across 21 story pages).
+**Then retry as a canary**: one article, load its story page, confirm the hero,
+then the rest, then `npm run check:media`.
+
+**Verification lesson worth keeping.** #501 was checked by confirming the DETAIL
+route's `content` byte-matched production. The site reads the **LIST** route and
+what broke was the **hero**. Content-field parity is not surface parity —
+measure the rendered page.
 
 ### Current Goals
-- [ ] Run the migration above.
+- [ ] Merge + deploy EL #504, then retry the migration as a canary.
 - [ ] **Elder review for eleven weighted articles across four communities.** Kristy
       Bloomfield's is recorded for Oonchiumpa. Jimmy Frank is in the system and one
       block away; Palm Island, Quandamooka and Kalkadoon have no approver identity.

--- a/thoughts/ledgers/CONTINUITY_LEDGER.md
+++ b/thoughts/ledgers/CONTINUITY_LEDGER.md
@@ -1,39 +1,68 @@
 # ACT Regenerative Studio - Continuity Ledger
 
-> Last Updated: 2026-08-08
-> Session: photographs restored, first elder review recorded, tooling trimmed
-> Full handoff: `thoughts/shared/handoffs/2026-08-08-photographs-consent-and-tooling.md`
+> Last Updated: 2026-08-09
+> Session: consent enforcement closed on the detail route, media URLs made host-neutral
+> Full handoff: `thoughts/shared/handoffs/2026-08-09-consent-enforcement-and-media-urls.md`
 
 ## Active Context
 
+### DO THIS FIRST — one migration is loaded and not run
+`docs/integrations/empathy-ledger/host-relative-media-urls-2026-08-08.sql`
+
+244 URLs across 40 articles, rewriting stored bodies to host-relative. Its
+prerequisite is **met**: PR #501 is merged and deployed, confirmed on the wire
+(production returns 5 absolute `/api/media` URLs, 0 host-relative).
+
+**Code first, data second — not the reverse.** Migrating before the read path
+absolutizes would emit host-relative URLs to every partner, which resolve
+against the partner's own domain and 404. That is the JusticeHub
+eight-broken-images bug recorded in `src/lib/media/serve-absolutize.test.ts`.
+
+After: confirm consumers still receive absolute URLs, then `npm run check:media`
+(baseline 0 dead across 21 story pages).
+
 ### Current Goals
+- [ ] Run the migration above.
 - [ ] **Elder review for eleven weighted articles across four communities.** Kristy
       Bloomfield's is recorded for Oonchiumpa. Jimmy Frank is in the system and one
       block away; Palm Island, Quandamooka and Kalkadoon have no approver identity.
       Run blocks from `docs/integrations/empathy-ledger/record-elder-review.sql`.
-- [ ] **Two builds in Empathy Ledger for consent to be end to end**: an article-level
-      elder review queue (the fields exist, no UI writes them), and consent
-      enforcement on `/api/v1/content-hub/articles/[slug]` (the list route does it,
-      the detail route does not, so a revoke does not stop it serving).
+      **This needs people, not code — it is the real blocker.**
+- [ ] **Article-level elder review queue in Empathy Ledger** — the fields exist, no
+      UI writes them, so every approval arrives as hand-written SQL. This is what
+      actually unblocks the item above. Another session was committing to that repo
+      hourly on 2026-08-08; **coordinate before starting**.
 - [ ] Conversation date for Kristy's approval — `elder_approved_at` currently holds
       the recording time, and the audit row says so.
+- [ ] 6 rows in `stories` carry a hardcoded `empathyledger.com` host on
+      `/api/v1/content-hub/stories/[id]`. Deliberately out of scope for #501.
 - [ ] 2,164 project photographs: 118 captioned, 0 credited. Unpublishable until that
       changes. Not a design backlog.
 - [ ] `primaryProject` and `themes` still empty across the corpus; `publishedAt` is
       still a migration artifact. No date is printed anywhere as a result.
+- [ ] Cleanup (deletions, left for Ben): remote branch `fix/host-relative-media-urls`
+      and worktree `~/Code/el-wt-hosturl`.
 
-### CORRECTION carried forward
-An earlier pass raised a consent RED claiming no approval covered public-web
-publication. It was wrong — it read the wiki decision records rather than the
-database. **Empathy Ledger is the system of record; query `syndication_consent`
-first.** The wiki records contradict it and should be made to defer to it.
+### CORRECTIONS carried forward
+1. **Query `syndication_consent` before believing the wiki.** Empathy Ledger is the
+   system of record. Already written into CLAUDE.md:65-67; no wiki record was found
+   still contradicting it. Note the table lives in project `yvnuayzslukamizrlhwb`
+   ("Empathy Ledger Enhanced"), **not** `tednluwflfhxyucgwigh` ("Empathy Ledger").
+2. **Trace the logic; do not infer behaviour from an observed response.** This
+   session I wrongly reported that the detail route enforced consent, because
+   revoked articles returned 403. They returned 403 from a `visibility='private'`
+   check; the route never queried consent at all. The two correlated perfectly
+   across the whole table. Correlation that clean is still not causation.
 
-### Recently Shipped (2026-08-08)
-107 dead photographs → 0 across all 21 live story pages, verified twice. First real
-elder review recorded in Empathy Ledger with provenance. Two false public claims
-removed from /stories. Hero text measurably AA-compliant. CLAUDE.md 20.5K → 9.4K with
-three false facts corrected. Nine skills made findable, three synced. Ten PRs merged
-across two repos; zero open here.
+### Recently Shipped (2026-08-08 evening)
+Five landings, each verified on a live surface rather than at the merge:
+ACT #75 (Field Notes 01 essay filed) · EL #496 (consent ledger governs the article
+detail route — production had been serving 40,469 characters of body to a site with
+no consent row) · EL #497 (a governed storage URL serves gated or not at all) ·
+EL #501 (absolutize body media URLs on read, not at rest) · 34 JusticeHub featured
+images registered and serving real bytes. Vercel Data Cache purged, which was the
+cause of production serving content matching nothing in the database.
+`check:media` 200 live / 0 dead across 21 story pages afterwards.
 
 ### Key Patterns Discovered
 - This project uses **Supabase** with pgvector for storage

--- a/thoughts/shared/handoffs/2026-08-09-consent-enforcement-and-media-urls.md
+++ b/thoughts/shared/handoffs/2026-08-09-consent-enforcement-and-media-urls.md
@@ -7,29 +7,48 @@ session worked down.
 
 ---
 
-## Read this first: the one thing left loaded
+## Read this first: the migration was run, it broke the site, and it is reverted
 
 `docs/integrations/empathy-ledger/host-relative-media-urls-2026-08-08.sql`
-is **written, verified safe, and NOT run**.
+was run on 2026-08-08. **It took the hero image off 13 of 21 ACT story pages
+within minutes.** It was reverted immediately and the data is byte-identical to
+before (0 host-relative, 39 absolute). `check:media` is back to 200 live / 0
+dead.
 
-Its prerequisite is now met: PR #501 is merged AND deployed to production,
-confirmed on the wire (production returns 5 absolute `/api/media` URLs and 0
-host-relative, content length 6668 unchanged). So the migration can be run.
+**Do not run it again until PR #504 is merged AND deployed.**
 
-**The order is not optional and is the opposite of the backfill below.**
+### What went wrong, because the shape of it matters
+
+#501 absolutized article bodies on the way out, but computed that value AFTER
+`extractFirstImage` had already read the stored form. So with bodies stored
+host-relative:
+
+1. `extractFirstImage` returns `/api/media/<id>/file` as the hero
+2. `resolveAssetUrl` had no branch for our own serve route
+3. so it fell to `startsWith('/') && sourceUrl` and resolved the path against
+   **the article's original source site**
+
+The output was not a broken-looking URL. It was a valid absolute URL to a host
+that never had the file. Only 13 broke because the other 8 had a featured image
+from `media_assets` or `import_metadata` and never reached the content fallback.
+
+**The verification lesson.** #501 was checked by confirming the DETAIL route's
+`content` field byte-matched production. The ACT site reads the **LIST** route,
+and what broke was the **hero**, which neither check looked at. Content-field
+parity is not surface parity. Measure the rendered page.
+
+### When #504 is deployed, retry as a canary
+
+Not all 39 at once. Migrate ONE article, load its story page, confirm the hero
+resolves, then do the rest and re-run `npm run check:media`.
+
+The ordering rule still holds and is the opposite of the backfill below:
 
 ```
 code first, then data -> consumers keep receiving absolute URLs throughout
 data first, then code -> every partner gets `/api/media/...`, resolves it
                          against its OWN domain, and 404s
 ```
-
-That second line is not hypothetical. It is the JusticeHub eight-broken-images
-bug, already recorded at the top of `src/lib/media/serve-absolutize.test.ts`.
-
-After running it: confirm on the wire that consumers still receive **absolute**
-URLs, then `npm run check:media` in this repo (baseline 0 dead across 21 story
-pages).
 
 ---
 

--- a/thoughts/shared/handoffs/2026-08-09-consent-enforcement-and-media-urls.md
+++ b/thoughts/shared/handoffs/2026-08-09-consent-enforcement-and-media-urls.md
@@ -1,0 +1,205 @@
+# Consent enforcement, a real hole closed, and one migration left loaded
+
+**Date:** 2026-08-09 (work done through the evening of 2026-08-08)
+**Branch:** everything merged. ACT `main` clean. EL `main` clean.
+**Follows:** `2026-08-08-photographs-consent-and-tooling.md`, whose open list this
+session worked down.
+
+---
+
+## Read this first: the one thing left loaded
+
+`docs/integrations/empathy-ledger/host-relative-media-urls-2026-08-08.sql`
+is **written, verified safe, and NOT run**.
+
+Its prerequisite is now met: PR #501 is merged AND deployed to production,
+confirmed on the wire (production returns 5 absolute `/api/media` URLs and 0
+host-relative, content length 6668 unchanged). So the migration can be run.
+
+**The order is not optional and is the opposite of the backfill below.**
+
+```
+code first, then data -> consumers keep receiving absolute URLs throughout
+data first, then code -> every partner gets `/api/media/...`, resolves it
+                         against its OWN domain, and 404s
+```
+
+That second line is not hypothetical. It is the JusticeHub eight-broken-images
+bug, already recorded at the top of `src/lib/media/serve-absolutize.test.ts`.
+
+After running it: confirm on the wire that consumers still receive **absolute**
+URLs, then `npm run check:media` in this repo (baseline 0 dead across 21 story
+pages).
+
+---
+
+## The correction that matters this session
+
+Mid-investigation I told Ben the article detail route **did** enforce consent,
+because revoked articles returned 403. That was wrong, and the code said so.
+
+The 403s came from an `article.visibility === 'private'` check. The route never
+queried `syndication_consent` at all. Every revoked article happened to also be
+`visibility='private'`, so the two correlated perfectly and the behaviour looked
+like enforcement. It was luck.
+
+**Rule: trace the logic, do not infer behaviour from an observed response.**
+A perfect correlation across the whole table is not causation.
+
+---
+
+## What shipped
+
+Five merges, all verified on live surfaces rather than at the merge.
+
+| PR | what | verified by |
+| --- | --- | --- |
+| ACT #75 | Field Notes 01 essay filed | 12/12 CI green |
+| EL #496 | consent ledger governs the article detail route | 403/200 against production with ACT's key |
+| EL #497 | governed storage URL serves gated or not at all | `check:media` 200 live / 0 dead |
+| EL #501 | absolutize body media URLs on read, not at rest | preview vs prod byte-identical |
+| (data) | 34 featured images registered | real bytes, `200 image/png 1,137,879` |
+
+### The hole that was real, and live
+
+`/api/v1/content-hub/articles/:slug` returned the full body without consulting
+`syndication_consent`. With ACT's own site key against production:
+
+- list route (`destination=act_el`): 26 articles, target **absent** — refused
+- detail route: **200, 40,469 characters of body**
+
+Not a latent bug. A site key could read the full text of articles that site had
+no consent for. Closed by #496; production now answers
+`403 {"error":"Consent for this article has not been granted..."}`.
+
+The security-relevant half is precedence: the consuming site resolves from the
+**site-scoped API key**, and `?destination=` is honoured only when the key names
+no site. The other way round, any key holder could aim at a site with no consent
+rows and read what their own site was refused. I wrote it backwards first and
+caught it on review.
+
+### Vercel Data Cache, not a stale deployment
+
+Production served article bodies that matched nothing in the database. Ruled out,
+in order: different code (`git diff` empty for content-hub), different database
+(both deployments resolve the same asset id to the same storage path with the
+same signing key), HTTP cache (`x-vercel-cache: MISS`, `age: 0`), and
+per-deployment cache (a fresh deploy still served stale bytes).
+
+What survived: **Vercel's Data Cache is per-project and survives deployments.**
+`vercel cache purge --type data` flipped production from 6953/raw to 6668/gated
+immediately. Confirmed by intervention.
+
+The tell that pointed at it: two articles production had never served returned
+database-exact bytes. Only previously-served articles were stale.
+
+### 34 featured images: broken, not leaking
+
+Framed in the last handoff as a fail-open leak. It was not. The `media` bucket is
+no longer public, so those raw URLs return `400 NoSuchBucket` — they served
+nothing. All 34 objects were still in the bucket, just unregistered, so nothing
+could sign a URL for them.
+
+Registered following the precedent already in the data
+(`ungoverned-public-media-backfill-2026-07-30`): `requires_consent=false`,
+`visibility='public'`, same tenant and operator ids. Marked
+`metadata.backfill = 'featured-image-backfill-2026-08-08'`, `reviewed: false`,
+alt text provisional and flagged.
+
+**Ben's call, twice stated: these images carry no people and are cleared for
+use.** I had wrongly inferred people from article slugs.
+
+All 34 are JusticeHub's. None are ACT's.
+
+---
+
+## Next, in the order I would take it
+
+### 1. Run the loaded migration
+See the top of this document. Prerequisite met. ~5 minutes plus verification.
+
+### 2. Elder review for eleven articles
+Unchanged and still the real blocker, because it needs people rather than code.
+`docs/integrations/empathy-ledger/record-elder-review.sql` has a block per
+community; run only the ones with an actual approval behind them.
+
+| community | articles | approver |
+| --- | --- | --- |
+| Warumungu / Tennant Creek | 2 | Jimmy Frank (`dda39576-…`), awaiting his approval |
+| Bwgcolman / Palm Island | 1 | none identified |
+| Quandamooka | 1 | none identified |
+| Kalkadoon | 1 | none identified |
+| not community-specific | 6 | may need none |
+
+Also outstanding: the conversation date for Kristy's approval, and whether it
+extends to the two ACT-authored pieces that mention Oonchiumpa.
+
+### 3. Article-level elder review queue (EL build)
+The thing that would replace hand-written SQL with a UI, and so actually unblock
+(2). Held off deliberately: another session was committing to that repo hourly
+all evening. **Coordinate before starting.**
+
+### 4. Smaller, still open
+- **6 rows in `stories`** carry the same hardcoded `empathyledger.com` host, on
+  `/api/v1/content-hub/stories/[id]`. Out of scope for #501 on purpose.
+- **2,164 project photographs**: 118 captioned, 0 credited, 75 with named people.
+  Content work, not code.
+- **`09c855ba feat(scripts): sweep partner sites for images served outside the
+  gate`** landed from another session. Mention the featured-image backfill to
+  whoever wrote it before they sweep.
+- **claude.ai connectors** — Adobe, Canva, Miro are ~110 unused tool definitions.
+  Only reachable from claude.ai settings.
+
+### 5. Leftover cleanup (deletions, so left for Ben)
+- remote branch `fix/host-relative-media-urls`
+- worktree `~/Code/el-wt-hosturl` (remove its two symlinks first, then
+  `git worktree remove` needs no `--force`)
+
+---
+
+## Traps worth not rediscovering
+
+- **`syndication_consent` lives in `yvnuayzslukamizrlhwb` ("Empathy Ledger
+  Enhanced"), NOT in the project named "Empathy Ledger"** (`tednluwflfhxyucgwigh`).
+  The last handoff's SQL block does not name a project and the obvious guess is
+  wrong.
+- **Vercel Data Cache survives deployments.** `x-vercel-cache: MISS` and `age: 0`
+  say nothing about it. A route can look uncached and still serve pre-migration
+  rows. Purge with `vercel cache purge --type data`.
+- **`VERCEL_ACCESS_TOKEN` in the environment is invalid.** The CLI rejects it.
+  `vercel login` (device flow) works; the CLI had no stored credentials.
+- **`gh pr merge --delete-branch` fails** in these repos because `main` is checked
+  out in another worktree. The merge still succeeds; only the local cleanup step
+  errors. Read the PR state rather than the command's exit.
+- **`gh pr checks` output is TAB-separated.** Grepping for `| pass |` matches
+  nothing and silently reports zero. My CI watcher did exactly this and I nearly
+  acted on `pass: 0, fail: 0`. Use `grep -cP '\tpass\t'`.
+- **A squash merge needs `git branch -D`, not `-d`** — the original commit is
+  never an ancestor of `main`. Verify the content landed before forcing.
+- **The `media` bucket is private.** Any `/storage/v1/object/public/media/...`
+  URL returns `400 NoSuchBucket`. Those URLs are dead, not leaking.
+- **`evaluateMediaGate` requires `visibility='public'` AND one of
+  `requires_consent=false | consent_obtained | consent_granted |
+  contained_consent`.** Registering an asset without one of those makes it
+  `pending`, which 403s. Registration alone does not make an image serve.
+- **`appBaseUrl()` is `http://localhost:4000` in the EL working tree.** It falls
+  back to the canonical production host only when the variable is unset, and
+  `NEXT_PUBLIC_APP_URL` is not in that project's Vercel production env list.
+- **EL `main` moved five times during one session** and another session held 68
+  uncommitted files in the working tree the whole time. Always
+  `git worktree add` off `origin/main`; never work in that tree.
+- **Zsh globs an unquoted `?`** in a URL passed to `gh api`, so the call fails
+  silently inside an `until` loop and polls forever.
+
+---
+
+## Gates
+
+- `npm run check:media` — rendered production story pages, **baseline 0**.
+  Confirmed 200 live / 0 dead after all of the above.
+- `npm run check:copy`, `npm run check:consent` — pass; pre-commit re-runs
+  `check:copy`.
+- EL pre-push gate needs `.env.local` present in the worktree, or the data-model
+  check fails with a postgres auth error. Symlink it in; do not `--no-verify`.
+- EL `tsc` baseline is **1247 errors** on `main`. Compare by set-diff, not count:
+  a flaky `TS2589` in `media/route.ts` moves whenever a shared type changes.


### PR DESCRIPTION
Session record for the evening of 2026-08-08, plus the two SQL files it produced — moved out of a session scratchpad into `docs/integrations/empathy-ledger/` so they survive a clear.

## The one thing still loaded

`host-relative-media-urls-2026-08-08.sql` is written, verified safe, and **not run**. Its prerequisite is now met: #501 is merged and deployed, confirmed on the wire (production returns 5 absolute `/api/media` URLs, 0 host-relative).

**Code first, data second.** The reverse emits host-relative URLs to every partner, which resolve against the partner's own domain and 404 — a bug this codebase has already had once, recorded in `serve-absolutize.test.ts`.

## What shipped

| PR | verified by |
| --- | --- |
| ACT #75 — Field Notes 01 filed | 12/12 CI green |
| EL #496 — consent ledger governs the article detail route | 403/200 against production |
| EL #497 — governed storage URL serves gated or not at all | `check:media` 200 live / 0 dead |
| EL #501 — absolutize body media URLs on read | preview vs prod byte-identical |
| 34 featured images registered | real bytes, `200 image/png 1,137,879` |

#496 closed something live and real: production was serving **40,469 characters of article body** to a site holding no consent row for it.

## A correction about my own reporting

Mid-session I said the detail route enforced consent, because revoked articles returned 403. They returned 403 from a `visibility='private'` check — the route never queried the consent ledger. Every revoked article happened to also be private, so the correlation was perfect and the behaviour looked like enforcement.

Written down as a rule: trace the logic, don't infer it from a response.

## Traps recorded

Eleven, each having cost time. Among them: `syndication_consent` is in the project **not** named "Empathy Ledger"; Vercel's Data Cache survives deployments and `x-vercel-cache` says nothing about it; `gh pr checks` output is tab-separated, so grepping for pipes silently reports zero passes — which nearly had me merge on a watcher reporting nothing.

Gates: `check:copy` and `check:consent` pass. Docs and SQL only; no `src/`, `config/` or `public/` files, so site behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)