### PR TITLE
handoff: the run finished — migration done, seven elder reviews recorded

### DIFF
--- a/thoughts/ledgers/CONTINUITY_LEDGER.md
+++ b/thoughts/ledgers/CONTINUITY_LEDGER.md
@@ -6,49 +6,63 @@
 
 ## Active Context
 
-### DO THIS FIRST — the migration was run, broke the site, and is reverted
-`docs/integrations/empathy-ledger/host-relative-media-urls-2026-08-08.sql`
+### NEXT SESSION IS A DIFFERENT JOB — UI/UX review, then a launch piece
+Launch is **tomorrow**. Two things, in order:
 
-Run 2026-08-08. **It took the hero off 13 of 21 ACT story pages.** Reverted
-immediately; data is byte-identical to before and `check:media` is back to
-200 live / 0 dead.
+1. **UI/UX review of the site, launch-ready.** Nothing below blocks it. The
+   consent, media and photograph layers are all done and verified; treat the site
+   as functionally sound and review it as a reader would.
+2. **The first large newsletter / blog post for launch.** Load the `act-voice`
+   skill BEFORE drafting, not after. No em-dashes. The essay the homepage speaks
+   in is now tracked at `compendium/04-story/what-the-road-corrects.md` — it is
+   the register to write in, and Field Notes 01 implies a series.
 
-**Do not run it again until EL PR #504 is merged AND deployed.** #501
-absolutized the body after `extractFirstImage` had already read the stored form,
-so the hero came out `/api/media/...` and `resolveAssetUrl` resolved it against
-the article's original source site — a valid URL to a host that never had the
-file. #504 resolves the body before anything reads it, in both routes, and gives
-`resolveAssetUrl` an explicit `/api/media/` branch.
+Useful for the launch piece: seven articles now carry recorded elder review, the
+photographs all resolve, and consent is enforced end to end. That is a real story
+about how the work is held, if it is wanted.
 
-**Then retry as a canary**: one article, load its story page, confirm the hero,
-then the rest, then `npm run check:media`.
-
-**Verification lesson worth keeping.** #501 was checked by confirming the DETAIL
-route's `content` byte-matched production. The site reads the **LIST** route and
-what broke was the **hero**. Content-field parity is not surface parity —
-measure the rendered page.
+### Everything from the 2026-08-08 evening run is DONE
+- **Media URL migration: COMPLETE.** 39 articles now stored host-relative, 0
+  absolute. It broke 13 heroes on the first attempt, was reverted, fixed by EL
+  #504, then retried as a canary (one article, verified at API AND rendered page,
+  then the rest). Final: `check:media` 200 live / 0 dead.
+- **Elder review: 7 articles recorded**, up from 1. Kristy Bloomfield
+  (Oonchiumpa), Jimmy Frank (Warumungu, 2), Uncle Allan Palm Island (Bwgcolman,
+  2), Shaun Fisher (Quandamooka), Brodie Germaine (Kalkadoon).
 
 ### Current Goals
-- [ ] Merge + deploy EL #504, then retry the migration as a canary.
-- [ ] **Elder review for eleven weighted articles across four communities.** Kristy
-      Bloomfield's is recorded for Oonchiumpa. Jimmy Frank is in the system and one
-      block away; Palm Island, Quandamooka and Kalkadoon have no approver identity.
-      Run blocks from `docs/integrations/empathy-ledger/record-elder-review.sql`.
-      **This needs people, not code — it is the real blocker.**
-- [ ] **Article-level elder review queue in Empathy Ledger** — the fields exist, no
-      UI writes them, so every approval arrives as hand-written SQL. This is what
-      actually unblocks the item above. Another session was committing to that repo
-      hourly on 2026-08-08; **coordinate before starting**.
-- [ ] Conversation date for Kristy's approval — `elder_approved_at` currently holds
-      the recording time, and the audit row says so.
+- [ ] UI/UX review, launch-ready (see above).
+- [ ] First large newsletter / blog post for launch.
+- [ ] **`the-power-of-indigenous-storytelling-a-community-perspective` is live and
+      probably should not be.** 1,123 characters, the shortest of the 21 by a wide
+      margin, subtitled "a community perspective", speaking for Indigenous
+      communities across Australia with no named community and no named person in
+      it. Reads as placeholder or generated filler. This is a publish/unpublish
+      call, not a consent one. **Worth settling before launch.**
+- [ ] **`elder_approved_by` has a FK to `auth.users`**, so it can only name someone
+      with a platform login. Six of the seven approvals could not use it — Jimmy
+      Frank, Uncle Allan, Shaun Fisher and Brodie Germaine are storytellers, not
+      users. Attribution lives in `syndication_audit_log` metadata instead, with
+      the reason stated on each row. The real fix is pointing that FK at
+      `storytellers`, or adding `elder_approved_by_storyteller_id`.
+- [ ] Whether **Richard Cassidy** has agreed to his own words being published in
+      `the-spirit-must-be-strong`. Uncle Allan's approval covers elder authority
+      for Country; it does not establish this, and the audit row says so.
+- [ ] Jimmy Frank would like to see his `/me` page with his content aligned. Not
+      looked at yet.
+- [ ] **Article-level elder review queue in Empathy Ledger** — every approval still
+      arrives as hand-written SQL. Another session was committing to that repo
+      hourly; coordinate before starting.
+- [ ] Conversation dates for all seven approvals — `elder_approved_at` holds the
+      recording time, and every audit row says so explicitly.
 - [ ] 6 rows in `stories` carry a hardcoded `empathyledger.com` host on
       `/api/v1/content-hub/stories/[id]`. Deliberately out of scope for #501.
-- [ ] 2,164 project photographs: 118 captioned, 0 credited. Unpublishable until that
-      changes. Not a design backlog.
+- [ ] 2,164 project photographs: 118 captioned, 0 credited. Not a design backlog.
 - [ ] `primaryProject` and `themes` still empty across the corpus; `publishedAt` is
-      still a migration artifact. No date is printed anywhere as a result.
-- [ ] Cleanup (deletions, left for Ben): remote branch `fix/host-relative-media-urls`
-      and worktree `~/Code/el-wt-hosturl`.
+      still a migration artifact.
+- [ ] Cleanup (deletions): branches `fix/host-relative-media-urls`,
+      `fix/absolutize-before-first-image`; worktrees `~/Code/el-wt-hosturl`,
+      `~/Code/el-wt-firstimg`. All merged; safe to delete.
 
 ### CORRECTIONS carried forward
 1. **Query `syndication_consent` before believing the wiki.** Empathy Ledger is the

--- a/thoughts/shared/handoffs/2026-08-09-consent-enforcement-and-media-urls.md
+++ b/thoughts/shared/handoffs/2026-08-09-consent-enforcement-and-media-urls.md
@@ -7,7 +7,36 @@ session worked down.
 
 ---
 
-## Read this first: the migration was run, it broke the site, and it is reverted
+## FINAL STATE (appended after the run completed)
+
+Everything below is now DONE. Read it for the reasoning, not for instructions.
+
+- **Migration COMPLETE.** 39 articles stored host-relative, 0 absolute.
+  `check:media` 200 live / 0 dead.
+- **EL #504 merged and deployed** — the fix for what broke below.
+- **Elder review: 7 articles**, up from 1. Kristy Bloomfield (Oonchiumpa), Jimmy
+  Frank (Warumungu ×2), Uncle Allan Palm Island (Bwgcolman ×2), Shaun Fisher
+  (Quandamooka), Brodie Germaine (Kalkadoon).
+- **`the-spirit-must-be-strong` was reclassified out of Block F** into Bwgcolman.
+  It opens on Richard Cassidy's words about Palm Island and mentions Palm Island
+  three times. The earlier "not tied to one community" grouping was wrong.
+
+**Next session is a different job: UI/UX review for launch, then the first large
+newsletter / blog post. Launch is tomorrow.** See the ledger.
+
+Two things left open that touch launch:
+
+1. `the-power-of-indigenous-storytelling-a-community-perspective` is live and
+   probably should not be. 1,123 characters, subtitled "a community
+   perspective", speaking for Indigenous communities with no named community or
+   person in it. A publish/unpublish call. **Settle before launch.**
+2. `elder_approved_by` has a FK to `auth.users`, so six of seven approvals could
+   not name their approver in the field built for it. Attribution is in
+   `syndication_audit_log` metadata with the reason on each row.
+
+---
+
+## What follows is the record of how the migration went wrong the first time
 
 `docs/integrations/empathy-ledger/host-relative-media-urls-2026-08-08.sql`
 was run on 2026-08-08. **It took the hero image off 13 of 21 ACT story pages


### PR DESCRIPTION
Closes out the evening run. The ledger led with a migration marked **do not run**; it has since been fixed, retried as a canary and completed — so leading with that would send the next session chasing something already done.

## Done

- **Media URL migration complete.** 39 articles stored host-relative, 0 absolute, `check:media` 200 live / 0 dead. It broke 13 heroes on the first attempt; EL #504 fixed the cause; the retry went **one article first** — verified at the API, the rendered page, and the full gate — then the remaining 38.
- **Elder review: 1 → 7 articles** across five communities, each with an audit row naming the approver, their storyteller id, and that the recorded time is not the conversation date.

| community | approver | articles |
|---|---|---|
| Arrernte / Mparntwe | Kristy Bloomfield | 1 |
| Warumungu / Tennant Creek | Jimmy Frank | 2 |
| Bwgcolman / Palm Island | Uncle Allan Palm Island | 2 |
| Quandamooka | Shaun Fisher | 1 |
| Kalkadoon / Mount Isa | Brodie Germaine | 1 |

## Two findings recorded in the data, not just here

**`elder_approved_by` has a FK to `auth.users`** — so six of seven approvals could not name their approver in the field built for it. The people who hold elder authority are storytellers, not account holders. Attribution lives in `syndication_audit_log` metadata with the reason on each row.

**`the-spirit-must-be-strong` was reclassified** out of "not tied to one community". It opens on Richard Cassidy's words about Palm Island and names it three times — it sits with Bwgcolman and always did.

## Next session is a different job

UI/UX review for launch, then the first large newsletter piece. **Launch is tomorrow.** The ledger now opens on that.

One thing worth settling first: `the-power-of-indigenous-storytelling-a-community-perspective` is live — 1,123 characters, subtitled "a community perspective", speaking for Indigenous communities without naming a single one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)