### PR TITLE
stories: give the article type a human label

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   getProjectEditorialArticles,
   getProjectEditorialFeature,
 } from '@/lib/empathy-ledger-editorial';
+import { formatArticleType } from '@/lib/editorial/article-type';
 import { getProjectFieldMedia } from '@/lib/projects/get-project-field-media';
 import {
   getFeaturedWorkConfigBySlug,
@@ -696,9 +697,9 @@ export default async function ProjectPage({
                 )}
                 <div className="space-y-4 p-6">
                   <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.24em] text-[#D9B786]">
-                    {projectEditorial.leadArticle.articleType ? (
+                    {formatArticleType(projectEditorial.leadArticle.articleType) ? (
                       <span className="rounded-full border border-[var(--we-warm-brown)] bg-white/5 px-3 py-1 text-[#F4ECDE]">
-                        {projectEditorial.leadArticle.articleType.replace(/_/g, ' ')}
+                        {formatArticleType(projectEditorial.leadArticle.articleType)}
                       </span>
                     ) : null}
                     {projectEditorial.leadArticle.publishedAt ? (
@@ -760,9 +761,9 @@ export default async function ProjectPage({
                   )}
                   <div className="space-y-3 p-5">
                     <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.24em] text-forest">
-                      {article.articleType ? (
+                      {formatArticleType(article.articleType) ? (
                         <span className="rounded-full bg-[#E8F3E6] px-3 py-1 text-[var(--we-olive)]">
-                          {article.articleType.replace(/_/g, ' ')}
+                          {formatArticleType(article.articleType)}
                         </span>
                       ) : null}
                       {article.publishedAt ? (

--- a/src/app/stories/[slug]/editorial-article.tsx
+++ b/src/app/stories/[slug]/editorial-article.tsx
@@ -14,6 +14,7 @@ import {
   prepareArticleHtml,
   readingTimeMinutes,
 } from "@/lib/editorial/article-html";
+import { formatArticleType } from "@/lib/editorial/article-type";
 import { ReadingProgress } from "@/components/editorial/ReadingProgress";
 import { ArticleGallery } from "@/components/editorial/ArticleGallery";
 import { RichTextMedia } from "@/components/editorial/RichTextMedia";
@@ -199,10 +200,10 @@ export async function EditorialArticleReader({
           ) : null}
           <div className="mt-8 flex flex-wrap items-center gap-5 font-[var(--font-sans)] text-[11px] uppercase tracking-[0.22em] text-[#CFA16B]/90">
             {post.authorName ? <span>{post.authorName}</span> : null}
-            {post.articleType ? (
+            {formatArticleType(post.articleType) ? (
               <>
                 <span aria-hidden="true" className="text-[#CFA16B]/40">·</span>
-                <span>{post.articleType}</span>
+                <span>{formatArticleType(post.articleType)}</span>
               </>
             ) : null}
             {readingMinutes ? (
@@ -387,7 +388,7 @@ export async function EditorialArticleReader({
                   </div>
                   <div className="flex flex-1 flex-col space-y-3 p-6">
                     <p className="font-[var(--font-sans)] text-[10px] font-semibold uppercase tracking-[0.3em] text-[var(--we-warm-brown)]">
-                      {other.articleType || "Editorial"}
+                      {formatArticleType(other.articleType) ?? "Editorial"}
                     </p>
                     <h3 className="font-[var(--font-display)] text-xl font-semibold leading-tight text-[var(--we-olive)] transition-colors group-hover:text-forest">
                       {other.title}

--- a/src/lib/editorial/article-type.test.ts
+++ b/src/lib/editorial/article-type.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatArticleType } from './article-type';
+
+describe('formatArticleType', () => {
+  it('maps the two types actually in the corpus', () => {
+    // 24 of 25 live articles are `editorial`; one is `story_feature`, and it
+    // was the one printing STORY_FEATURE into a reader-facing byline.
+    expect(formatArticleType('editorial')).toBe('Editorial');
+    expect(formatArticleType('story_feature')).toBe('Feature');
+  });
+
+  it('never returns a string containing an underscore', () => {
+    for (const token of [
+      'editorial',
+      'story_feature',
+      'story_photo_essay',
+      'some_future_type_upstream',
+    ]) {
+      expect(formatArticleType(token)).not.toMatch(/_/);
+    }
+  });
+
+  it('degrades an unknown token to Title Case instead of dropping it', () => {
+    expect(formatArticleType('some_future_type')).toBe('Some future type');
+    expect(formatArticleType('op-ed')).toBe('Op ed');
+  });
+
+  it('tolerates the shapes the API actually sends for "no type"', () => {
+    expect(formatArticleType(null)).toBeNull();
+    expect(formatArticleType(undefined)).toBeNull();
+    expect(formatArticleType('')).toBeNull();
+    expect(formatArticleType('   ')).toBeNull();
+  });
+
+  it('normalises casing and stray whitespace', () => {
+    expect(formatArticleType('  STORY_FEATURE  ')).toBe('Feature');
+    expect(formatArticleType('Editorial')).toBe('Editorial');
+  });
+});

--- a/src/lib/editorial/article-type.ts
+++ b/src/lib/editorial/article-type.ts
@@ -1,0 +1,42 @@
+/**
+ * Human labels for Empathy Ledger's article-type tokens.
+ *
+ * `articleType` arrives from Empathy Ledger as a snake_case machine token
+ * (`editorial`, `story_feature`). Three of the four places that rendered it
+ * printed the token more or less as-is, so a reader on the Oonchiumpa story
+ * saw `STORY_FEATURE` sitting in the byline between the author and the reading
+ * time. The two project-page call sites each did their own `.replace(/_/g,' ')`,
+ * which fixed the underscore and nothing else, and drifted from each other.
+ *
+ * One formatter, so the taxonomy stays Empathy Ledger's business and the label
+ * a reader sees is always a word. Unknown tokens degrade to Title Case rather
+ * than disappearing: a new type added upstream should look unremarkable here,
+ * not vanish silently.
+ */
+
+const ARTICLE_TYPE_LABELS: Record<string, string> = {
+  editorial: 'Editorial',
+  story_feature: 'Feature',
+  story_photo_essay: 'Photo essay',
+  field_note: 'Field note',
+  interview: 'Interview',
+};
+
+export function formatArticleType(
+  articleType: string | null | undefined
+): string | null {
+  if (!articleType) return null;
+
+  const key = articleType.trim().toLowerCase();
+  if (!key) return null;
+
+  const known = ARTICLE_TYPE_LABELS[key];
+  if (known) return known;
+
+  // Unknown token: make it readable rather than leaking snake_case.
+  return key
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^./, (c) => c.toUpperCase());
+}

--- a/thoughts/ledgers/CONTINUITY_LEDGER.md
+++ b/thoughts/ledgers/CONTINUITY_LEDGER.md
@@ -31,14 +31,28 @@ about how the work is held, if it is wanted.
   2), Shaun Fisher (Quandamooka), Brodie Germaine (Kalkadoon).
 
 ### Current Goals
-- [ ] UI/UX review, launch-ready (see above).
+- [x] UI/UX review, launch-ready. Done 2026-08-09 against prod. Site is sound:
+      all 65 sitemap routes 200, contrast gate 0 violations across 26 routes,
+      0 console errors, no horizontal overflow at 390px, hero rotation correct
+      (video + field name + line change together), /stories count live and honest.
+      Four findings, none blocking, in the handoff. The one worth fixing before
+      launch is the raw `STORY_FEATURE` token in story bylines
+      (`src/app/stories/[slug]/editorial-article.tsx:205` and `:390`).
 - [ ] First large newsletter / blog post for launch.
-- [ ] **`the-power-of-indigenous-storytelling-a-community-perspective` is live and
-      probably should not be.** 1,123 characters, the shortest of the 21 by a wide
-      margin, subtitled "a community perspective", speaking for Indigenous
-      communities across Australia with no named community and no named person in
-      it. Reads as placeholder or generated filler. This is a publish/unpublish
-      call, not a consent one. **Worth settling before launch.**
+- [x] **`the-power-of-indigenous-storytelling-a-community-perspective`:
+      UNPUBLISHED 2026-08-09** on Ben's call. Was `status=published,
+      visibility=public` since 2026-01-08; now `status=draft, visibility=private`
+      (article id `b21fafab-255d-4c62-b989-9f165213063b`, project
+      `yvnuayzslukamizrlhwb`). Reason recorded on an `article_reviews` row
+      (`review_type=editor`, `decision=reject`, reviewer_name "Ben Knight"), not in
+      `syndication_audit_log`: this was an editorial call, and filing it as a
+      consent event would have falsely recorded that a community withdrew.
+      Verified: live page 404s, sitemap dropped 66 to 65 entries, /stories count
+      decremented 21 to 20, control story still 200.
+      Restore by reversing status/visibility on that id.
+      **Note for the elder-approval FK gap below: `article_reviews.reviewer_id`
+      already FKs to `storytellers`, and `reviewer_name` is free text.** That may
+      be the existing mechanism the fix wants, rather than a new column.
 - [ ] **`elder_approved_by` has a FK to `auth.users`**, so it can only name someone
       with a platform login. Six of the seven approvals could not use it — Jimmy
       Frank, Uncle Allan, Shaun Fisher and Brodie Germaine are storytellers, not


### PR DESCRIPTION
## What a reader was seeing

`STORY_FEATURE` sat in the byline of the Oonchiumpa story, between the author and the reading time. The story page printed Empathy Ledger's raw `articleType` token, so an internal taxonomy key was being read as editorial copy on the surface the launch points people at.

## What changed

Four places rendered the token and each did something different. The story byline and the "keep reading" rail printed it verbatim. The two project-page call sites each ran their own `.replace(/_/g,' ')`, which fixed the underscore, nothing else, and had already drifted apart.

One formatter (`src/lib/editorial/article-type.ts`) now serves all four. The taxonomy stays Empathy Ledger's business and what a reader sees is always a word. Unknown tokens degrade to Title Case rather than vanishing, so a type added upstream looks unremarkable here instead of disappearing without anyone noticing.

Only 1 of the 25 live articles carries `story_feature`. The other 24 are `editorial`, which reads the same on every page and so tells a reader nothing. **Whether that label earns its place at all is a separate question, deliberately left alone here.**

## Verification

Checked on a clean dev server off this tree, not the long-running one on `:3001` (which turned out to be serving stale code and would have read as the fix failing):

- byline reads `Benjamin Knight · Feature · 7 min read`
- "keep reading" rail reads `Editorial`
- no underscore token survives anywhere in the rendered HTML
- `tsc` clean; 27 tests pass, up from 22 with 5 new ones for the formatter

## Consent gate

The pre-commit gate blocked this because it touches the story renderer. Answered from the database rather than waved through: every one of the 20 slugs the site serves has an approved, unrevoked `syndication_consent` row scoped to `act-regenerative-studio`. 0 missing, 0 revoked. The change is presentational and touches no visibility logic.

Worth noting the gate's own suggested query returns 848 articles because it is not scoped by destination. The site-scoped number is 20.

## Also in here

The ledger commit records two things from this session: the `the-power-of-indigenous-storytelling-a-community-perspective` unpublish (Ben's editorial call, now 404s, reason recorded on an `article_reviews` row rather than `syndication_audit_log`, because filing an editorial decision in a consent table would falsely record that a community withdrew), and the launch UI review.

The review found the site launch-sound: 65 routes 200, contrast gate clean across 26 routes, 0 console errors, no overflow at 390px, hero rotation pairing video, field name and line correctly.

Three findings left unfixed, none blocking: burned-in text in the Confessions hero clip colliding with the hero's own text layer; standalone mobile CTAs at ~13px tall; and hovering a field seed holding the current field rather than previewing the hovered one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)