### PR TITLE
handoff: the launch review, a story taken down, and a draft that must wait

### DIFF
--- a/compendium/04-story/what-the-site-refuses.md
+++ b/compendium/04-story/what-the-site-refuses.md
@@ -1,0 +1,103 @@
+---
+title: What the Site Refuses
+slug: what-the-site-refuses
+series: Field Notes 02
+author: Benjamin Knight
+excerpt: "On a website that can say no, and the story we took down on the morning it launched"
+date: 2026-08-09
+status: draft
+last_updated: 2026-08-09
+---
+
+# What the Site Refuses
+
+**A Curious Tractor · Field Notes 02**
+
+*On a website that can say no, and the story we took down on the morning it launched*
+
+Benjamin Knight, 9 August 2026
+
+> **Draft.** Three things need Ben's decision before this ships. They are listed at
+> the end under "Before this goes out". Do not send it until they are settled.
+
+This morning we took a story off the site.
+
+It had been published since January. It was titled "The Power of Indigenous Storytelling", subtitled "A Community Perspective", and it ran to 1,123 characters, the shortest thing we had published by a wide margin. It spoke for Indigenous communities across Australia and named none of them. No community. No person. It carried a heading that read "Voices from the Community" and nothing underneath it.
+
+Nobody complained. No community asked for it to come down. It sat there for seven months, quietly doing the thing we say we are against.
+
+●
+
+A website going live is usually an occasion for addition. Here is the new thing. Here is more of us.
+
+We are opening ours by taking something away.
+
+The story was not a consent failure. Every article on the site has an approved, current permission recorded against it, scoped to this site, revocable at the source. That machinery held. What failed was older and more ordinary: somebody wrote a page about Indigenous storytelling without an Indigenous storyteller in it, and the page was useful enough to the organisation that nobody looked at it again.
+
+That is the failure worth naming on launch day. Not a broken rule. An unexamined convenience.
+
+●
+
+The site does not hold the stories.
+
+Empathy Ledger does. The pages here are a window onto a record kept somewhere else, and the permission travels with the story rather than sitting in a filing cabinet behind it. If a storyteller withdraws, the page stops resolving. Not at the next rebuild, not when somebody remembers. On the next read.
+
+We did not have that in July. We found, checking something unrelated, that the article route had never once asked the consent ledger anything. It gated on a flag on the article itself. The two happened to agree on every story in the table, which is the most dangerous way for a thing to be wrong: it had been serving forty thousand characters of somebody's story to a site holding no recorded permission for it at all, and every test we had said green.
+
+We fixed it. Then we went back through the corpus. Twenty stories are live. Seven of them now carry an Elder's recorded approval, across five communities, with the reasoning written on each record rather than in somebody's memory.
+
+Seven of twenty is not a number to be proud of. It is a number to publish, because publishing it is the only thing that makes the other thirteen visible.
+
+●
+
+There is a test in the last of these notes: what arrived, what left, and what stayed?
+
+Applied to a website it gets uncomfortable quickly. What arrives is a story. What leaves is usually the story again, faster, into a funding room or a feed. What stays is meant to be the relationship, and the relationship is exactly the part a content management system is worst at holding.
+
+So the useful question is not what the site publishes. It is what the site refuses.
+
+It refuses a story whose permission has lapsed. It refuses a photograph the ledger cannot account for. As of this morning it refuses a page that speaks on behalf of people it cannot name.
+
+None of that is generous. It is the minimum, arriving late.
+
+●
+
+Some of what we built is not open yet.
+
+There is no storyteller directory. There was one, and it went behind a hold because a single profile in it had no clear permission, and one is enough. The public question tool is closed until somebody with standing has reviewed what it does with what people tell it. The internal wiki stays internal.
+
+We could have opened all three today and explained later. The explanation would have been good. That is the problem with explanations.
+
+●
+
+This is an invitation, and a narrower one than last time.
+
+If you hold a story that has travelled further than you agreed to, tell us. That includes stories on this site. Especially stories on this site. The record has an owes list and it is not decoration.
+
+If you are a community organisation with something you want tested, and the authority to tell us no, we would like to hear what is happening rather than a polished brief.
+
+If you work on consent infrastructure and think we have this wrong, say so with reasons. We would rather be corrected in August than admired in September.
+
+●
+
+The site is live. It is smaller than it was yesterday.
+
+There is a version of a launch that lists what has been built. This is the other kind. A story came down this morning because it could not name the people it claimed to speak for, and the only thing that makes that worth writing about is that it took us seven months to look.
+
+The owes list is longer than the site.
+
+That is where we begin.
+
+---
+
+## Before this goes out
+
+Three decisions, none of them mine.
+
+**1. The forty-thousand-character disclosure.** The paragraph about the article route never querying the consent ledger is a real admission that community content was served without recorded permission. It is the most honest thing in the piece and the most exposing. The register of Field Notes 01 argues for keeping it. Ben decides whether a launch is the right place for it, and whether any storyteller should hear it from us before they read it here.
+
+**2. No Elders are named.** Seven approvals are recorded and every name is in the ledger. They are deliberately absent from this piece. Naming an Elder in a launch announcement as evidence of ACT's good practice is a different act from recording their approval in a database, and it is closer to using them than crediting them. If any of them would want to be named, that is a conversation to have with them first, not a decision to make in a draft.
+
+**3. The domain.** The piece says "the site is live" and names no address, because the act.place cutover is Ben's and the ledger has DNS unconfirmed. Fill the address in once it is pointed, and not before.
+
+**Verified for this draft** (Empathy Ledger project `yvnuayzslukamizrlhwb`, 9 August 2026): 20 stories live on the site; all 20 hold an approved, unrevoked consent row scoped to `act-regenerative-studio`, 0 missing and 0 revoked; 7 of the 20 carry `elder_approved`. The unpublished article was 1,123 characters, published 8 January 2026, and now returns 404. The forty-thousand-character figure is 40,469, carried from the 2026-08-08 handoff rather than re-queried, and is the one number here I have not confirmed myself.

--- a/thoughts/ledgers/CONTINUITY_LEDGER.md
+++ b/thoughts/ledgers/CONTINUITY_LEDGER.md
@@ -1,25 +1,64 @@
 # ACT Regenerative Studio - Continuity Ledger
 
 > Last Updated: 2026-08-09
-> Session: consent enforcement closed on the detail route, media URLs made host-neutral
-> Full handoff: `thoughts/shared/handoffs/2026-08-09-consent-enforcement-and-media-urls.md`
+> Session: launch UI review, the "community perspective" story taken down, Field Notes 02 drafted
+> Full handoff: `thoughts/shared/handoffs/2026-08-09-launch-review-and-the-story-taken-down.md`
 
 ## Active Context
 
-### NEXT SESSION IS A DIFFERENT JOB — UI/UX review, then a launch piece
-Launch is **tomorrow**. Two things, in order:
+### NEXT SESSION: FINAL CHECKING FOR LAUNCH
+The code side is done and has been since 2026-08-07. What is left is Ben's, and
+most of it is outside this repo. Nothing in this repo blocks the launch.
 
-1. **UI/UX review of the site, launch-ready.** Nothing below blocks it. The
-   consent, media and photograph layers are all done and verified; treat the site
-   as functionally sound and review it as a reader would.
-2. **The first large newsletter / blog post for launch.** Load the `act-voice`
-   skill BEFORE drafting, not after. No em-dashes. The essay the homepage speaks
-   in is now tracked at `compendium/04-story/what-the-road-corrects.md` — it is
-   the register to write in, and Field Notes 01 implies a series.
+**Do not start new work. Verify, then stop.**
 
-Useful for the launch piece: seven articles now carry recorded elder review, the
-photographs all resolve, and consent is enforced end to end. That is a real story
-about how the work is held, if it is wanted.
+1. **Ben's cutover, his to do, not ours.** Point act.place DNS, **with the
+   current MX records recorded first: that is the one way this breaks his
+   email.** Then `NEXT_PUBLIC_SITE_URL=https://act.place` in Vercel Production,
+   ship a build, repoint the EL webhook, sweep GHL, add Search Console.
+2. **The moment Ben says act.place is pointed**, run all three gates against it
+   and spot-check robots host, sitemap `<loc>` hosts, and a canonical on one
+   static page plus one `/stories/[slug]`:
+   - `LAUNCH_CHECK_BASE_URL=https://act.place node scripts/check-launch-site.mjs`
+   - `REDIRECT_CHECK_BASE_URL=https://act.place node scripts/check-launch-redirects.mjs`
+   - `CONTRAST_BASE_URL=https://act.place node scripts/check-contrast.mjs`
+3. **The launch piece is drafted and must not ship yet.**
+   `compendium/04-story/what-the-site-refuses.md` (Field Notes 02, 1,213 words,
+   written in the `what-the-road-corrects.md` register with `act-voice` loaded).
+   Three decisions are Ben's and are listed at the foot of the draft: the
+   40,469-character disclosure, whether any Elder is named (none are, on
+   purpose), and the domain. **Do not send it until those are settled.**
+
+**One number in that draft is not verified.** `40,469` is carried from the
+2026-08-08 handoff and was not re-queried. Confirm before it goes to print.
+
+**Do not report 848 as this site's corpus.** The consent gate's own suggested
+query is not scoped by destination and returns the whole EL corpus. The
+site-scoped number is 20.
+
+### Everything from the 2026-08-08 evening run is DONE
+- **Media URL migration: COMPLETE.** 39 articles now stored host-relative, 0
+  absolute. It broke 13 heroes on the first attempt, was reverted, fixed by EL
+  #504, then retried as a canary (one article, verified at API AND rendered page,
+  then the rest). Final: `check:media` 200 live / 0 dead.
+- **Elder review: 7 articles recorded**, up from 1. Kristy Bloomfield
+  (Oonchiumpa), Jimmy Frank (Warumungu, 2), Uncle Allan Palm Island (Bwgcolman,
+  2), Shaun Fisher (Quandamooka), Brodie Germaine (Kalkadoon).
+  **These names stay in the ledger and out of public copy** unless the person
+  has been asked. Recording an approval and citing it as proof of good practice
+  are different acts.
+
+### Traps found 2026-08-09
+- **The long-running dev server on :3001 serves stale code.** It runs from this
+  working tree but rendered a byline that does not exist in the source. It reads
+  exactly like a fix having failed. Use a fresh server on a free port, or
+  restart :3001 first.
+- **Vercel preview deployments are behind SSO.** Curling one returns Vercel's
+  login page with a 200, so a "bad string is absent" grep passes and means
+  nothing. Only Ben can check a preview.
+- **The pre-commit consent gate fires on `editorial-article.tsx`.** Correct
+  behaviour. Answer it from the database and pass the answer through
+  `CONSENT_CHECKED=`. Never write that line to get past it.
 
 ### Everything from the 2026-08-08 evening run is DONE
 - **Media URL migration: COMPLETE.** 39 articles now stored host-relative, 0
@@ -36,9 +75,21 @@ about how the work is held, if it is wanted.
       0 console errors, no horizontal overflow at 390px, hero rotation correct
       (video + field name + line change together), /stories count live and honest.
       Four findings, none blocking, in the handoff. The one worth fixing before
-      launch is the raw `STORY_FEATURE` token in story bylines
-      (`src/app/stories/[slug]/editorial-article.tsx:205` and `:390`).
-- [ ] First large newsletter / blog post for launch.
+      launch, the raw `STORY_FEATURE` token in story bylines, is **FIXED and
+      live**: PR #78, merged `555473f`, new formatter at
+      `src/lib/editorial/article-type.ts` with 5 tests, all four call sites
+      converted, 20 story pages swept on prod with 0 raw tokens remaining.
+      Three findings left unfixed on purpose, all in PR #78: burned-in text in
+      the Confessions hero clip colliding with the hero's own text layer;
+      standalone mobile CTAs at ~13px tall; hover on a field seed holding the
+      current field rather than previewing the hovered one.
+- [~] First large newsletter / blog post for launch. **DRAFTED, NOT SENT** at
+      `compendium/04-story/what-the-site-refuses.md`. Field Notes 02, 1,213
+      words, `act-voice` loaded before drafting, em-dash and AI-vocab and
+      `check:copy` all clean. Opens on the story taken down rather than on what
+      was built. Three decisions at the foot of the draft are Ben's and block
+      sending: the 40,469-character disclosure, naming any Elder (none named, on
+      purpose), and the domain.
 - [x] **`the-power-of-indigenous-storytelling-a-community-perspective`:
       UNPUBLISHED 2026-08-09** on Ben's call. Was `status=published,
       visibility=public` since 2026-01-08; now `status=draft, visibility=private`

--- a/thoughts/shared/handoffs/2026-08-09-launch-review-and-the-story-taken-down.md
+++ b/thoughts/shared/handoffs/2026-08-09-launch-review-and-the-story-taken-down.md
@@ -1,0 +1,166 @@
+# Launch review, a story taken down, and a draft waiting on three decisions
+
+**Session:** 2026-08-09
+**Branch:** `main` at `555473f`, clean, nothing unpushed
+**Next job:** final checking for launch
+
+---
+
+## What this session was
+
+The ledger said: UI/UX review, then the launch piece. Both done. One thing
+settled that the previous session had flagged and left live.
+
+## The story is down
+
+`the-power-of-indigenous-storytelling-a-community-perspective` is unpublished on
+Ben's call. It had been `status=published, visibility=public` since 8 January
+2026.
+
+Article id `b21fafab-255d-4c62-b989-9f165213063b`, Empathy Ledger project
+`yvnuayzslukamizrlhwb`. Now `status=draft, visibility=private`. Restore by
+reversing those two fields on that id.
+
+**The reason is recorded on an `article_reviews` row, not in
+`syndication_audit_log`.** That was deliberate. `syndication_audit_log` is
+consent-scoped and requires a `story_id`, `tenant_id` and `site_id`. Filing an
+editorial decision there would have recorded that a community withdrew consent.
+No community asked for this to come down. The row is `review_type=editor`,
+`decision=reject`, `reviewer_name='Ben Knight'`, with the grounds and the
+restore instruction in `notes` and `requested_changes`.
+
+Verified on live surfaces rather than at the write: page 404s, sitemap dropped
+66 to 65, `/stories` count decremented 21 to 20 on its own, control story still
+200.
+
+**Incidental find that matters for the elder-approval FK gap:**
+`article_reviews.reviewer_id` already has a foreign key to `storytellers`, and
+`reviewer_name` is free text. The mechanism that gap wants may already exist.
+Look there before adding `elder_approved_by_storyteller_id` to `articles`.
+
+## The UI review: the site is launch-sound
+
+Checked against prod, not the dev server.
+
+- All 65 sitemap routes return 200
+- Contrast gate: 0 WCAG AA violations across 26 routes
+- 0 console errors (64 warnings, all one benign Next.js CSS-preload notice)
+- No horizontal overflow at 390px; h1 wraps; hero seeds are 44px tall
+- Hero rotation correct: video, field name and line change together
+- `/stories` counts are live, not hardcoded
+
+**One finding fixed and shipped.** `STORY_FEATURE` was rendering as a raw
+machine token in story bylines. PR #78, merged as `555473f`, verified live on
+prod: 20 story pages swept, 0 raw tokens. New formatter at
+`src/lib/editorial/article-type.ts` with 5 tests, now used by all four call
+sites (the two `/projects` ones each had their own drifted `.replace()`).
+
+**Three findings left unfixed, none blocking.** All recorded in PR #78.
+
+1. The Confessions hero clip has text burned into the video ("No one is
+   available to take your call right now.") and the hero's own text layer sits
+   on top of it. Two typographic layers fighting. Only the Art field's clip.
+2. Standalone mobile CTAs are ~13px tall ("Read the field notes", "Ask a
+   question", "Enter The Harvest story"). Inline links are exempt from WCAG
+   target size; standalone CTAs less clearly so.
+3. Hovering a field seed holds the current field rather than previewing the
+   hovered one. Possibly intended as pause-on-hover, reads as unresponsive.
+
+## The launch piece is drafted and must not ship yet
+
+`compendium/04-story/what-the-site-refuses.md`. Field Notes 02, 1,213 words,
+written after loading `act-voice`, in the register of
+`compendium/04-story/what-the-road-corrects.md`. Em-dash check, AI-vocab check
+and `check:copy` all clean.
+
+It opens on subtraction rather than addition: the story taken down, and the
+seven months it sat there before anyone looked.
+
+**Three decisions are Ben's and are listed at the foot of the draft:**
+
+1. **The 40,469-character disclosure.** The draft includes the admission that
+   the article route never queried the consent ledger, and production served a
+   story's body to a site with no recorded permission. Most honest thing in the
+   piece, most exposing. A storyteller might reasonably want to hear it from ACT
+   before reading it in a launch email.
+2. **No Elders are named, deliberately.** Seven approvals are recorded and every
+   name is in the ledger. Naming an Elder in a launch announcement as evidence
+   of good practice is closer to using them than crediting them. If any would
+   want naming, that is a conversation with them, not a drafting decision.
+3. **The domain.** The piece says "the site is live" and names no address,
+   because the cutover is Ben's and DNS is unconfirmed.
+
+## Numbers, and which one is not mine
+
+Queried directly against `yvnuayzslukamizrlhwb` on 2026-08-09:
+
+- 20 stories live on the site
+- all 20 hold an approved, unrevoked `syndication_consent` row scoped to
+  `act-regenerative-studio`: 0 missing, 0 revoked
+- 7 of the 20 carry `elder_approved`
+
+**`40,469` is carried from the 2026-08-08 handoff and was not re-queried this
+session.** It is the one figure in the draft I did not confirm. If it goes to
+print, confirm it first.
+
+Note the consent gate's own suggested query returns **848** articles because it
+is not scoped by destination. The site-scoped number is 20. Do not report 848 as
+this site's corpus.
+
+## Traps found this session
+
+- **The long-running dev server on :3001 was serving stale code.** It runs from
+  this working tree but rendered a byline that does not exist in the source (a
+  date field the component does not have, and no reading time). It read exactly
+  like the fix having failed. Verify on a fresh server on a free port, or
+  restart :3001 before trusting anything on it.
+- **Vercel preview deployments are behind SSO.** Curling one returns Vercel's
+  login page with a 200. A grep for "bad string absent" on that HTML passes and
+  means nothing. Ben can open previews logged in; an agent cannot.
+- **The pre-commit consent gate fires on `editorial-article.tsx`.** It is
+  correct to fire. Answer it from the database and pass the answer through
+  `CONSENT_CHECKED=`. Never write that line to get past it.
+
+## Next session: final checking for launch
+
+The code side has been done since 2026-08-07. What is left is Ben's and is
+mostly outside this repo.
+
+- [ ] **Ben: the cutover.** Point act.place DNS, **with the current MX records
+      recorded first, the one way this breaks his email.** Set
+      `NEXT_PUBLIC_SITE_URL=https://act.place` in Vercel Production, ship a
+      build, repoint the EL webhook, sweep GHL, add Search Console.
+- [ ] **On Ben's word that act.place is pointed**, re-run both gates against it
+      and spot-check robots host, sitemap `<loc>` hosts, and a canonical on one
+      static page plus one `/stories/[slug]`:
+      - `LAUNCH_CHECK_BASE_URL=https://act.place node scripts/check-launch-site.mjs`
+      - `REDIRECT_CHECK_BASE_URL=https://act.place node scripts/check-launch-redirects.mjs`
+      - `CONTRAST_BASE_URL=https://act.place node scripts/check-contrast.mjs`
+- [ ] **Ben: the three decisions on the launch piece**, then it can go out.
+- [ ] Optional, flagged and deliberately not done: the three UI findings above;
+      deleting the 19 dormant `/projects/*` redirect rules now the closure is
+      permanent; removing the `/projects` and `/events` page code, which needs
+      an import check first.
+
+## Still open from before, unchanged
+
+- Whether **Richard Cassidy** has agreed to his own words being published in
+  `the-spirit-must-be-strong`. Uncle Allan's approval covers elder authority for
+  Country; it does not establish this, and the audit row says so.
+- Jimmy Frank would like to see his `/me` page with his content aligned.
+- Article-level elder review queue in Empathy Ledger. Every approval still
+  arrives as hand-written SQL.
+- Conversation dates for all seven approvals. `elder_approved_at` holds the
+  recording time and every audit row says so.
+- 6 rows in `stories` carry a hardcoded `empathyledger.com` host.
+- 2,164 project photographs: 118 captioned, 0 credited.
+- `primaryProject` and `themes` empty across the corpus; `publishedAt` still a
+  migration artifact.
+- Cleanup, safe: EL branches `fix/host-relative-media-urls`,
+  `fix/absolutize-before-first-image`; worktrees `~/Code/el-wt-hosturl`,
+  `~/Code/el-wt-firstimg`. All merged.
+
+## State at handoff
+
+Prod verified 2026-08-09: home 200, unpublished article 404, 20 stories in
+sitemap, 65 routes total. `main` at `555473f`, clean, in sync with origin.


### PR DESCRIPTION
Closes out 2026-08-09. Next session is **final checking for launch**, and the code side has been done since 7 August. What remains is the cutover, which is Ben's.

## A story came down

`the-power-of-indigenous-storytelling-a-community-perspective` is unpublished. Public since 8 January: 1,123 characters speaking for Indigenous communities across Australia, naming none of them, with a "Voices from the Community" heading and no voices under it. Nobody complained. It sat there seven months doing the thing we say we are against.

The reason is recorded on an `article_reviews` row rather than `syndication_audit_log`. That table is consent-scoped, and filing an editorial decision there would have recorded that a community withdrew. None did.

Verified on live surfaces, not at the write: page 404s, sitemap 66 to 65, `/stories` count decremented on its own, control story still 200. Restore by reversing `status`/`visibility` on article id `b21fafab-255d-4c62-b989-9f165213063b`.

## The review

The site is launch-sound. 65 routes 200, contrast 0 violations across 26 routes, 0 console errors, no overflow at 390px, hero rotation pairing video and field name and line correctly, `/stories` counts live rather than hardcoded.

One finding was worth fixing and is fixed and live in `555473f` (PR #78). Three are left alone on purpose and are recorded in that PR: burned-in text in the Confessions hero clip colliding with the hero's own text layer, standalone mobile CTAs at ~13px, and hover-holds-current-field on the hero seeds.

## Field Notes 02 is drafted and must NOT ship

`compendium/04-story/what-the-site-refuses.md`. 1,213 words, `act-voice` loaded before drafting, in the `what-the-road-corrects.md` register. Em-dash, AI-vocab and `check:copy` all clean.

Three decisions at the foot of the draft are Ben's and block sending:

1. Whether the 40,469-character consent disclosure belongs in a launch email
2. Whether any Elder is named. **None are, deliberately.** Recording an approval and citing it as proof of good practice are different acts
3. The domain, which is not pointed yet

**`40,469` is the one figure not verified this session.** It is carried from the 2026-08-08 handoff. Confirm before print.

## Three traps worth not rediscovering

- **The long-running dev server on `:3001` serves stale code.** It runs from this working tree but rendered a byline that does not exist in the source. It reads exactly like a fix having failed.
- **Vercel previews sit behind SSO.** Curling one returns a login page with a 200, so any "bad string is absent" check passes and means nothing.
- **The consent gate's own suggested query is not scoped by destination.** It reports 848 articles where this site has 20. Do not quote 848 as this site's corpus.

## Verified for this handoff

Empathy Ledger `yvnuayzslukamizrlhwb`, 2026-08-09: 20 stories live, all 20 with an approved unrevoked consent row scoped to `act-regenerative-studio` (0 missing, 0 revoked), 7 carrying `elder_approved`. Prod: home 200, unpublished article 404, 20 stories in sitemap, 65 routes total.

Docs and a draft only. No runtime code in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)