### PR TITLE
Say whose organisation this is where it is actually read

### DIFF
--- a/src/app/fields/[field]/page.tsx
+++ b/src/app/fields/[field]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { FieldStoryPrototype } from "@/app/prototypes/living-field/field-story";
 import { FieldWriting } from "@/components/fields/FieldWriting";
+import { FieldAuthorityNote } from "@/components/fields/FieldAuthorityNote";
 import { livingFields, livingFieldsById } from "@/data/living-field";
 import { pageMetadata } from "@/lib/seo/site";
 
@@ -18,6 +19,11 @@ export default async function FieldPage({params}:{params:Promise<{field:string}>
           "use client" and shared with /prototypes/living-field, while this reads
           the server-only editorial snapshot. */}
       <FieldWriting fieldId={story.id} fieldName={story.name}/>
+      {/* Every field page describes work alongside Elders and communities, so
+          every field page says whose organisation this is. /goods carried this
+          and 307s to /fields/goods in production, which left it unsaid where it
+          is actually read. */}
+      <FieldAuthorityNote/>
     </>
   );
 }

--- a/src/components/fields/FieldAuthorityNote.tsx
+++ b/src/components/fields/FieldAuthorityNote.tsx
@@ -1,0 +1,40 @@
+/**
+ * Where ACT stands, on every field page.
+ *
+ * All five live field pages describe work alongside Elders, Aboriginal
+ * communities and Country. None of them said whose organisation this is. The
+ * page that did say it, /goods, is a 307 to /fields/goods in production, so the
+ * statement was written where no reader reaches it.
+ *
+ * The words are the essay's own ("What the Road Corrects", Field Notes 01) and
+ * match /about, so the site says this the same way wherever it says it.
+ */
+export function FieldAuthorityNote() {
+  return (
+    <section
+      className="border-t border-rule bg-bg px-8 py-16 md:px-12 lg:px-20"
+      aria-labelledby="field-authority-note"
+    >
+      <div className="mx-auto max-w-6xl">
+        <p className="font-sans text-eyebrow font-semibold uppercase text-clay-text">
+          Where we stand
+        </p>
+        <h2
+          id="field-authority-note"
+          className="mt-4 max-w-2xl font-display text-2xl font-light tracking-display text-ink md:text-3xl"
+        >
+          Who we are, and who we are not
+        </h2>
+        <p className="mt-6 max-w-2xl font-body text-base leading-relaxed text-muted-deep">
+          A Curious Tractor is not a First Nations organisation and does not
+          speak as one. When we are invited into work with First Nations
+          communities, our responsibility is to follow community authority, be
+          clear about what we hold, and accept correction, refusal and silence
+          as part of the work. A relationship is not consent in perpetuity. A
+          good history together does not turn the next visit into an
+          entitlement.
+        </p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
All five live field pages describe work alongside Elders, Aboriginal communities and Country. None of them said who ACT is.

Verified against production before writing anything:

| page | Elder | Aboriginal | on Country | statement |
| --- | --- | --- | --- | --- |
| `/fields/goods` | 1 | 3 | 4 | none |
| `/fields/justice` | 3 | 3 | 3 | none |
| `/fields/empathy` | 3 | 1 | 1 | none |
| `/fields/harvest` | 1 | 1 | 1 | none |
| `/fields/art` | 1 | 1 | 1 | none |

The page that did carry the statement was `/goods`, which is a **307 to `/fields/goods`** in production. So it was written where no reader reaches it, which is the same as not having written it. `/economy` and `/studio` are the same shape and are deliberately dark for launch, confirmed by Ben.

This puts it on the field template, so it appears on all five. The words are taken verbatim from `/about` and from "What the Road Corrects", so the site does not develop two ways of saying the same thing.

## Verification

Rendered on all five field pages locally. `tsc` clean, tests pass, `check:copy` passes, and `check:contrast` reports no WCAG AA violations across 26 routes.

## Context

Found while checking why the entity corrections in #80 were not visible in production. They had landed on three pages that all redirect. Two of those are meant to be dark; the third, `/goods`, sends readers to `/fields/goods`, which is where this gap was.

An audit of all 44 live reachable pages found no community-ownership overclaims, no non-existent entity names, and no tax-deductibility claims. This was the only real gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)