### PR TITLE
Fix ACT syndicated editorial media reliability

### DIFF
--- a/scripts/sync-el-editorial.mjs
+++ b/scripts/sync-el-editorial.mjs
@@ -285,7 +285,11 @@ async function fetchAllSiteArticles() {
     url.searchParams.set('limit', '100');
     url.searchParams.set('destination', EMPATHY_LEDGER_EDITORIAL_DESTINATION);
 
-    const payload = await fetchJson(url.toString());
+    // ACT publishes this snapshot to the open web, so it must consume the
+    // anonymous public feed. An integration API key may legitimately see
+    // community-scoped records, but that access must never promote them into
+    // ACT's public static build.
+    const payload = await fetchJson(url.toString(), false);
     const pageItems = Array.isArray(payload.articles) ? payload.articles : [];
     articles.push(...pageItems);
 
@@ -298,7 +302,7 @@ async function fetchAllSiteArticles() {
 
 async function fetchArticleDetail(slug) {
   const url = new URL(`/api/v1/content-hub/articles/${slug}`, EMPATHY_LEDGER_URL);
-  return fetchJson(url.toString());
+  return fetchJson(url.toString(), false);
 }
 
 function resolveProjectSlugs(detail, article, projectLookup, projectEditorialRecipes) {
@@ -474,10 +478,17 @@ async function main() {
         ? buildProjectSlugLookup(projectCodeRegistry)
         : buildProjectLookup(Array.from(mergedRecords.values()));
     const siteArticles = await fetchAllSiteArticles();
+    const publiclyPublishedArticles = siteArticles.filter((article) => {
+      if (article.visibility === 'public') return true;
+      console.warn(
+        `[sync:el-editorial] withholding ${article.slug}: destination approval does not override article visibility (${article.visibility || 'unset'})`
+      );
+      return false;
+    });
 
     const limit = pLimit(6);
     const detailedArticles = await Promise.all(
-      siteArticles.map((article) =>
+      publiclyPublishedArticles.map((article) =>
         limit(async () => {
           try {
             const detail = await fetchArticleDetail(article.slug);

--- a/src/data/empathy-ledger-editorial.generated.json
+++ b/src/data/empathy-ledger-editorial.generated.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-15T08:29:58.737Z",
-  "sourceUrl": "https://empathy-ledger-v2.vercel.app",
+  "generatedAt": "2026-08-24T03:28:59.328Z",
+  "sourceUrl": "https://empathyledger.com",
   "siteSlug": "act-regenerative-studio",
   "editorialDestination": "act_el",
   "featuredHomeArticleSlugs": [
@@ -53,40 +53,40 @@
       "alt": "Black Cockatoo Valley aerial moving through fog above the canopy"
     }
   },
-  "articleCount": 21,
+  "articleCount": 15,
   "projectArticleCounts": {
-    "justicehub": 8,
+    "justicehub": 5,
     "goods": 1,
-    "empathy-ledger": 3,
-    "the-harvest": 2,
-    "act-farm": 2,
-    "goods-on-country": 5,
-    "black-cockatoo-valley": 2
+    "empathy-ledger": 2,
+    "the-harvest": 1,
+    "act-farm": 1,
+    "goods-on-country": 4,
+    "black-cockatoo-valley": 1
   },
   "projectEditorial": {
     "justicehub": {
       "sectionEyebrow": "Field writing",
       "sectionTitle": "Writing connected to this project",
       "sectionDescription": "JusticeHub writing should surface the strongest public argument, the clearest proof points, and the pieces that move from policy language into lived consequence.",
-      "articleCount": 8,
+      "articleCount": 5,
       "leadArticleSlug": "justicehub-a-platform-for-community-led-justice-solutions",
       "supportingArticleSlugs": [
         "contained-where-policy-meets-flesh",
         "beyond-bars-joe-kwons-journey-to-reshape-society",
-        "the-kids-are-not-alright-how-queensland-is-failing-its-most-vulnerable-young-people-and-what-we-can-do-about-it"
+        "oonchiumpa-what-happens-when-community-leads"
       ],
       "featuredArticleSlugs": [
         "justicehub-a-platform-for-community-led-justice-solutions",
         "contained-where-policy-meets-flesh",
         "beyond-bars-joe-kwons-journey-to-reshape-society",
-        "the-kids-are-not-alright-how-queensland-is-failing-its-most-vulnerable-young-people-and-what-we-can-do-about-it"
+        "oonchiumpa-what-happens-when-community-leads"
       ]
     },
     "goods-on-country": {
       "sectionEyebrow": "Field writing",
       "sectionTitle": "Writing connected to this project",
       "sectionDescription": "Goods writing should stay close to practical utility, local making, and the communities shaping what these products are actually for.",
-      "articleCount": 5,
+      "articleCount": 4,
       "leadArticleSlug": "wilya-janta-a-paradigm-shift-in-housing-for-remote-aboriginal-communities",
       "supportingArticleSlugs": [
         "at-the-speed-of-ceremony-learning-partnership-on-palm-island",
@@ -104,13 +104,10 @@
       "sectionEyebrow": "Field writing",
       "sectionTitle": "Writing connected to this project",
       "sectionDescription": "Harvest writing should feel seasonal, local, and close to the social life of the place rather than like generic food or venue marketing.",
-      "articleCount": 2,
-      "leadArticleSlug": "building-the-act-ecosystem-a-vision-for-community-centered-technology",
-      "supportingArticleSlugs": [
-        "what-the-road-corrects"
-      ],
+      "articleCount": 1,
+      "leadArticleSlug": "what-the-road-corrects",
+      "supportingArticleSlugs": [],
       "featuredArticleSlugs": [
-        "building-the-act-ecosystem-a-vision-for-community-centered-technology",
         "what-the-road-corrects"
       ]
     },
@@ -118,14 +115,12 @@
       "sectionEyebrow": "Field writing",
       "sectionTitle": "Writing connected to this project",
       "sectionDescription": "Empathy Ledger writing should foreground consent, narrative sovereignty, and the deeper question of who gets to hold and move a story.",
-      "articleCount": 3,
-      "leadArticleSlug": "building-the-act-ecosystem-a-vision-for-community-centered-technology",
+      "articleCount": 2,
+      "leadArticleSlug": "oonchiumpa-what-happens-when-community-leads",
       "supportingArticleSlugs": [
-        "oonchiumpa-what-happens-when-community-leads",
         "what-the-road-corrects"
       ],
       "featuredArticleSlugs": [
-        "building-the-act-ecosystem-a-vision-for-community-centered-technology",
         "oonchiumpa-what-happens-when-community-leads",
         "what-the-road-corrects"
       ]
@@ -134,14 +129,11 @@
       "sectionEyebrow": "Field writing",
       "sectionTitle": "Writing connected to this project",
       "sectionDescription": "Black Cockatoo Valley writing should stay grounded in place, slower practice, and the wider field this land base makes possible.",
-      "articleCount": 2,
+      "articleCount": 1,
       "leadArticleSlug": "conversation-camp",
-      "supportingArticleSlugs": [
-        "building-the-act-ecosystem-a-vision-for-community-centered-technology"
-      ],
+      "supportingArticleSlugs": [],
       "featuredArticleSlugs": [
-        "conversation-camp",
-        "building-the-act-ecosystem-a-vision-for-community-centered-technology"
+        "conversation-camp"
       ]
     }
   },
@@ -193,7 +185,7 @@
         "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
         "slug": "benjamin-knight",
         "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
+        "avatarUrl": null,
         "bio": null
       },
       "media": {
@@ -245,8 +237,51 @@
       },
       "ctas": [],
       "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/what-the-road-corrects",
+      "canonicalUrl": "https://empathyledger.com/articles/what-the-road-corrects",
       "localPath": "/stories/what-the-road-corrects",
+      "syndicationDestinations": [
+        "act_el"
+      ]
+    },
+    {
+      "id": "7a1035bc-5097-497e-b5c4-856bfbc51484",
+      "title": "Wilya Janta: A Paradigm Shift in Housing for Remote Aboriginal Communities",
+      "slug": "wilya-janta-a-paradigm-shift-in-housing-for-remote-aboriginal-communities",
+      "subtitle": null,
+      "excerpt": "Tonight reminded us that the solutions we seek already exist in Aboriginal wisdom and ways of doing - we just need to listen, learn, and follow proper protocols in bringing them into the present.",
+      "content": "<p id=\"\">Last night at <a href=\"https://acca.melbourne/\" id=\"\">ACCA (Australian Centre for Contemporary Art)</a>, surrounded by the powerful works of the Tennant Creek Brio (<em id=\"\">Tennant Creek Brio: Juparnta Ngattu Minjinypa Iconocrisis</em>), I was struck by how art, housing, and community empowerment weave together into something far greater than their individual threads. Just days earlier, I had stood under the Story Tree on Palm Island, where Uncle Alan Palm Island shared language and story during a Welcome to Country ceremony. As young rangers tended the fire and carried out their roles under watchful eyes, I was reminded that every meaningful partnership begins with proper protocol and deep respect for place.</p><p id=\"\">As <a href=\"https://www.wilyajanta.org/about\" id=\"\">Jimmy Frank Jupurrula</a> guided us through the exhibition, his stories brought each work to vivid life. Pausing before a large-scale canvas alive with bold marks and ancestral symbols, he shared how these works speak to both the ancient songlines of his country and the contemporary challenges facing his community. Hand-painted marks, created with discarded materials and industrial paint, tell stories of connection to country that stretch back countless generations while confronting present-day realities of life in Tennant Creek.</p><p id=\"\">\"These aren't just paintings,\" Jimmy explained, gesturing to a particularly powerful piece. \"They're our way of showing you how we see our country, how we live with it, how we need to build with it.\" His words carried the same energy that fuels his work with <a href=\"https://www.wilyajanta.org/\" id=\"\">Wilya Janta</a> - a deep understanding that whether through art or architecture, the goal is to help people understand the profound connections between culture, country, and community. The materiality of his work - the use of found objects, industrial materials, and bold gestural marks - mirrors the Wilya Janta project's ambition to transform existing resources into something that serves community needs while honouring cultural protocols.</p><p id=\"\">As we moved through the space, Jimmy's stories wove together the temporal and the spiritual, the practical and the profound. His art, like the housing initiative he champions, carries the weight of tradition while boldly pushing into new territory. It's a powerful reminder that innovation in remote communities must be grounded in cultural understanding and proper protocols, whether we're discussing housing design or artistic practice.</p><p id=\"\">What makes Wilya Janta's approach so revolutionary is how it challenges the status quo of remote housing. As Dr. Simon Quilty puts it, \"no medicines are going to fix this problem\" - the issue isn't just about building structures, it's about addressing systemic inequalities. This truth was reinforced during my visit to Palm Island's local store, where a simple bed frame and mattress cost nearly $1,000, with quality and durability issues compounded by the logistics of island life. These aren't just housing or furniture challenges - they're symptoms of deeper systemic issues that require community-led solutions.</p><p id=\"\">Standing in ACCA last night, watching the Tennant Creek Brio's \"audaciously punk attitude\" challenge conventional art world norms, I couldn't help but think of Uncle Alan Palm Island proudly showing us his hospital mural and the traditional canoe in the council boardroom - tangible symbols of connection, resilience, and the long history of cultural exchange. Like the Brio's art and Wilya Janta's housing vision, these artefacts speak to both ancient wisdom and future possibilities.</p><p id=\"\">Wilya Janta's pilot project embodies this understanding. Their approach isn't just about building houses - it's about building a new model of community empowerment. Every aspect, from the initial design concepts to ongoing maintenance, is guided by community input and cultural protocols. The incorporation of features like communal living spaces and outdoor kitchens reflects a deep understanding of how homes need to support cultural practices and family life.</p><p id=\"\">The name \"Wilya Janta\" itself - \"standing strong\" or \"standing together\" in Warumungu language - captures the essence of this approach. It's about collective strength, about communities having the agency to shape their own solutions. The organisation's constitution, grounded in the story of Julawarra and Gilygi, demonstrates their commitment to honouring protocols while building bridges between Indigenous and non-Indigenous ways of working.</p><p id=\"\">What I witnessed at ACCA wasn't just an art exhibition or a fundraiser - it was a testament to what's possible when we truly support community-led change. Like watching the young rangers on Palm Island step confidently into teaching roles while sharing their knowledge of country, it demonstrated the power of enabling communities to write their own stories of regeneration and growth.</p><p id=\"\">Just as Uncle Alan Palm Island's mural at the Palm Island hospital depicts the ancient stories of sea country and trade routes - showing how his Elders' canoes navigated waters for thousands of years - the Wilya Janta pilot project charts a new course forward while honouring old ways. As the project advances, supported by philanthropic donations and potential government partnerships, it carries the potential to transform not just housing in Tennant Creek, but our entire approach to working with remote communities. In the council boardroom on Palm Island, Uncle Alan showed us the traditional canoe that his ancestors used for trade and connection - a physical reminder that innovation and tradition have always worked hand in hand in Aboriginal communities. Like that canoe, Wilya Janta's work is about creating vessels that carry both practical purpose and cultural meaning - spaces where cultural intelligence leads, where traditional knowledge guides innovation, and where every step forward strengthens the relationships that make lasting change possible. The stories in Uncle Alan's hospital mural and the traditional canoe in the boardroom remind us that the solutions we seek have deep roots in Aboriginal wisdom and ways of doing - we just need to listen, learn, and follow proper protocols in bringing them into the present.</p><p id=\"\">This is the revolution that Wilya Janta are leading - one that challenges us to think differently about how we create change in remote Australia. Like the morning ceremony at Palm Island's Story Tree, it reminds us that true transformation moves at the speed of ceremony, not commerce. It's not about imposing solutions from outside, but about standing together to create change that honours both tradition and innovation, that respects protocol while pushing boundaries, that builds houses while building community power.</p>",
+      "authorName": "Benjamin Knight",
+      "authorBio": null,
+      "articleType": "editorial",
+      "primaryProject": null,
+      "relatedProjects": [],
+      "relatedProjectSlugs": [
+        "goods-on-country"
+      ],
+      "publishedAt": "2026-03-25T22:45:19.558574+00:00",
+      "createdAt": null,
+      "updatedAt": null,
+      "tags": [],
+      "themes": [],
+      "featuredImageUrl": null,
+      "featuredImageAlt": null,
+      "storyteller": {
+        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
+        "slug": "benjamin-knight",
+        "displayName": "Benjamin Knight",
+        "avatarUrl": null,
+        "bio": null
+      },
+      "media": {
+        "photoCount": 0,
+        "videoCount": 0,
+        "photoPreviews": [],
+        "videoPreviews": []
+      },
+      "ctas": [],
+      "visibility": "public",
+      "canonicalUrl": "https://empathyledger.com/articles/wilya-janta-a-paradigm-shift-in-housing-for-remote-aboriginal-communities",
+      "localPath": "/stories/wilya-janta-a-paradigm-shift-in-housing-for-remote-aboriginal-communities",
       "syndicationDestinations": [
         "act_el"
       ]
@@ -277,7 +312,7 @@
         "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
         "slug": "benjamin-knight",
         "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
+        "avatarUrl": null,
         "bio": null
       },
       "media": {
@@ -340,284 +375,8 @@
       },
       "ctas": [],
       "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/historys-wounds-and-tomorrows-possibilities",
+      "canonicalUrl": "https://empathyledger.com/articles/historys-wounds-and-tomorrows-possibilities",
       "localPath": "/stories/historys-wounds-and-tomorrows-possibilities",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "7a1035bc-5097-497e-b5c4-856bfbc51484",
-      "title": "Wilya Janta: A Paradigm Shift in Housing for Remote Aboriginal Communities",
-      "slug": "wilya-janta-a-paradigm-shift-in-housing-for-remote-aboriginal-communities",
-      "subtitle": null,
-      "excerpt": "Tonight reminded us that the solutions we seek already exist in Aboriginal wisdom and ways of doing - we just need to listen, learn, and follow proper protocols in bringing them into the present.",
-      "content": "<p id=\"\">Last night at <a href=\"https://acca.melbourne/\" id=\"\">ACCA (Australian Centre for Contemporary Art)</a>, surrounded by the powerful works of the Tennant Creek Brio (<em id=\"\">Tennant Creek Brio: Juparnta Ngattu Minjinypa Iconocrisis</em>), I was struck by how art, housing, and community empowerment weave together into something far greater than their individual threads. Just days earlier, I had stood under the Story Tree on Palm Island, where Uncle Alan Palm Island shared language and story during a Welcome to Country ceremony. As young rangers tended the fire and carried out their roles under watchful eyes, I was reminded that every meaningful partnership begins with proper protocol and deep respect for place.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1333px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1333px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/19afc35a-1253-42e1-99e6-94dd88a6b56e/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">This collection of 10 artworks at the entrance of &nbsp;gallery one highlight the importance of cultural protocol*. The installation is made up of works by a number of The Brio members, and includes drawings, paintings and cultural markings inscribed on reclaimed mining maps. There are also found signs that refer to land rights and mining. Included in this collection are works by Jimmy Frank Jupurrula and Joseph Williams Jungarayi, two cultural leaders in Tennant Creek. Beginning the exhibition with these works is a way to remind viewers of the importance of following cultural protocols as they enter the exhibition space. The symbols and shapes in the artworks reference these laws and sacred places on Country. The signs collected from Tennant Creek speak to the European laws and rules enforced upon those living in Tennant Creek and Indigenous communities. Here the artists have reclaimed and inverted these laws, maps and signs, for example by adding text: ‘Please clean up the mess you’ve…have finished messing up my Country. This is Aboriginal Land.’</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/03c4ac7d-45dc-4097-9d4c-5fcc14d76ae0/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\">Jimmy in front of more of the exhibition pieces</strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1333px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1333px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/215c27da-4baf-4e71-a4b5-7da202a5a235/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\">Palm Island smoking ceremony in front of the Story Tree</strong></figcaption></figure><p id=\"\">As <a href=\"https://www.wilyajanta.org/about\" id=\"\">Jimmy Frank Jupurrula</a> guided us through the exhibition, his stories brought each work to vivid life. Pausing before a large-scale canvas alive with bold marks and ancestral symbols, he shared how these works speak to both the ancient songlines of his country and the contemporary challenges facing his community. Hand-painted marks, created with discarded materials and industrial paint, tell stories of connection to country that stretch back countless generations while confronting present-day realities of life in Tennant Creek.</p><p id=\"\">\"These aren't just paintings,\" Jimmy explained, gesturing to a particularly powerful piece. \"They're our way of showing you how we see our country, how we live with it, how we need to build with it.\" His words carried the same energy that fuels his work with <a href=\"https://www.wilyajanta.org/\" id=\"\">Wilya Janta</a> - a deep understanding that whether through art or architecture, the goal is to help people understand the profound connections between culture, country, and community. The materiality of his work - the use of found objects, industrial materials, and bold gestural marks - mirrors the Wilya Janta project's ambition to transform existing resources into something that serves community needs while honouring cultural protocols.</p><p id=\"\">As we moved through the space, Jimmy's stories wove together the temporal and the spiritual, the practical and the profound. His art, like the housing initiative he champions, carries the weight of tradition while boldly pushing into new territory. It's a powerful reminder that innovation in remote communities must be grounded in cultural understanding and proper protocols, whether we're discussing housing design or artistic practice.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/ead665cd-7378-4ccc-bc77-290f6e1a72a0/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Jimmy in front of Kunari 2024 (which translates as lightening dreaming) represents an Indigenous mythical story, in which a ‘Black Zeus’ figure sends a storm as a consequence for breaking cultural protocol (taking water without permission). The large concrete arm was salvaged from an abandoned roadhouse near Tennant Creek, and was originally attached to a large sculpture of The Hulk. Now transformed, the arm acts as a spear thrower, speaking both about customary Aboriginal law and Indigenous peoples’ strength and resilience despite the ongoing impacts of colonisation.</em></strong></figcaption></figure><p id=\"\">What makes Wilya Janta's approach so revolutionary is how it challenges the status quo of remote housing. As Dr. Simon Quilty puts it, \"no medicines are going to fix this problem\" - the issue isn't just about building structures, it's about addressing systemic inequalities. This truth was reinforced during my visit to Palm Island's local store, where a simple bed frame and mattress cost nearly $1,000, with quality and durability issues compounded by the logistics of island life. These aren't just housing or furniture challenges - they're symptoms of deeper systemic issues that require community-led solutions.</p><p id=\"\">Standing in ACCA last night, watching the Tennant Creek Brio's \"audaciously punk attitude\" challenge conventional art world norms, I couldn't help but think of Uncle Alan Palm Island proudly showing us his hospital mural and the traditional canoe in the council boardroom - tangible symbols of connection, resilience, and the long history of cultural exchange. Like the Brio's art and Wilya Janta's housing vision, these artefacts speak to both ancient wisdom and future possibilities.</p><p id=\"\">Wilya Janta's pilot project embodies this understanding. Their approach isn't just about building houses - it's about building a new model of community empowerment. Every aspect, from the initial design concepts to ongoing maintenance, is guided by community input and cultural protocols. The incorporation of features like communal living spaces and outdoor kitchens reflects a deep understanding of how homes need to support cultural practices and family life.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1540px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1540px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/a2f1cdd4-ef8c-4113-ac65-c046e0950ef5/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Diane Stokes Nampin, outside the donga where she lives with her family on the edge of Tennant Creek. Diane has no mains power or running water.&nbsp;Photo by Andrew Quilty</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2352px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2352px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/e8c983b0-4fda-47ad-9f90-9b62b66d49d2/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong><em>Remote Northern Territory communities often face specific hardships in comparison to the average Australian. These difficulties contribute to larger issues, including social and economic inequality, that continue to negatively impact these communities. </em></strong><a href=\"https://www.wilyajanta.org/our-work\" id=\"\"><strong><em>Taken from the Wilya Janta website.</em></strong></a></figcaption></figure><p id=\"\">The name \"Wilya Janta\" itself - \"standing strong\" or \"standing together\" in Warumungu language - captures the essence of this approach. It's about collective strength, about communities having the agency to shape their own solutions. The organisation's constitution, grounded in the story of Julawarra and Gilygi, demonstrates their commitment to honouring protocols while building bridges between Indigenous and non-Indigenous ways of working.</p><p id=\"\">What I witnessed at ACCA wasn't just an art exhibition or a fundraiser - it was a testament to what's possible when we truly support community-led change. Like watching the young rangers on Palm Island step confidently into teaching roles while sharing their knowledge of country, it demonstrated the power of enabling communities to write their own stories of regeneration and growth.</p><p id=\"\">Just as Uncle Alan Palm Island's mural at the Palm Island hospital depicts the ancient stories of sea country and trade routes - showing how his Elders' canoes navigated waters for thousands of years - the Wilya Janta pilot project charts a new course forward while honouring old ways. As the project advances, supported by philanthropic donations and potential government partnerships, it carries the potential to transform not just housing in Tennant Creek, but our entire approach to working with remote communities. In the council boardroom on Palm Island, Uncle Alan showed us the traditional canoe that his ancestors used for trade and connection - a physical reminder that innovation and tradition have always worked hand in hand in Aboriginal communities. Like that canoe, Wilya Janta's work is about creating vessels that carry both practical purpose and cultural meaning - spaces where cultural intelligence leads, where traditional knowledge guides innovation, and where every step forward strengthens the relationships that make lasting change possible. The stories in Uncle Alan's hospital mural and the traditional canoe in the boardroom remind us that the solutions we seek have deep roots in Aboriginal wisdom and ways of doing - we just need to listen, learn, and follow proper protocols in bringing them into the present.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/4a92caf8-a503-45cc-acbd-46363aa8a44a/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\">Uncle Alan Palm Island's mural</strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/55ccb492-c804-4ebe-9e1d-857ba411ba57/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">A&nbsp;traditional canoe in the Palm Island Council boardroom</em></strong></figcaption></figure><p id=\"\">This is the revolution that Wilya Janta are leading - one that challenges us to think differently about how we create change in remote Australia. Like the morning ceremony at Palm Island's Story Tree, it reminds us that true transformation moves at the speed of ceremony, not commerce. It's not about imposing solutions from outside, but about standing together to create change that honours both tradition and innovation, that respects protocol while pushing boundaries, that builds houses while building community power.</p>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": null,
-      "relatedProjects": [],
-      "relatedProjectSlugs": [
-        "goods-on-country"
-      ],
-      "publishedAt": "2026-03-25T22:45:19.558574+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": "https://empathyledger.com/api/media/19afc35a-1253-42e1-99e6-94dd88a6b56e/file",
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 8,
-        "videoCount": 0,
-        "photoPreviews": [
-          {
-            "url": "https://empathyledger.com/api/media/19afc35a-1253-42e1-99e6-94dd88a6b56e/file",
-            "title": null,
-            "alt_text": null
-          },
-          {
-            "url": "https://empathyledger.com/api/media/03c4ac7d-45dc-4097-9d4c-5fcc14d76ae0/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/215c27da-4baf-4e71-a4b5-7da202a5a235/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/ead665cd-7378-4ccc-bc77-290f6e1a72a0/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/a2f1cdd4-ef8c-4113-ac65-c046e0950ef5/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/e8c983b0-4fda-47ad-9f90-9b62b66d49d2/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/4a92caf8-a503-45cc-acbd-46363aa8a44a/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/55ccb492-c804-4ebe-9e1d-857ba411ba57/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          }
-        ],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/wilya-janta-a-paradigm-shift-in-housing-for-remote-aboriginal-communities",
-      "localPath": "/stories/wilya-janta-a-paradigm-shift-in-housing-for-remote-aboriginal-communities",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "afef20ca-770e-4680-be39-ad636106feb7",
-      "title": "Seeds of Change: Walking with Elders and Youth on Kalkadoon Country",
-      "slug": "seeds-of-change-walking-with-elders-and-youth-on-kalkadoon-country",
-      "subtitle": null,
-      "excerpt": "Returning to Kalkadoon Country (Mount Isa) became a profound lesson in community-led change. Supporting Brodie's evolution as a youth mentor, I witnessed wisdom flowing from two key elders: Uncle George, whose decades as a Police Liaison Officer taught him that real youth work happens through consistent presence, and Gary at the Men's Shed, whose practical approach shows how healing happens through doing. A simple create bed project wove through these conversations, transforming from initial setbacks into moments of dignity and connection - particularly when building with community members like Mark. Aunty Joan's careful preservation of cultural knowledge through her self-taught writing grounded these experiences in deeper tradition, reminding us that Indigenous wisdom offers pathways through modern challenges. As Uncle George said, \"If you speak from the heart and you tell, and you say the right things and you speak the truth, people listen\" - a guidance that proved true throughout this journey of learning and connection on Kalkadoon Country.",
-      "content": "<p id=\"\">‍<em id=\"\">November 2024</em></p><h2 id=\"\">Returning to Country</h2><p id=\"\">The plane touches down on Kalkadoon Country, known colonially as Mount Isa, and immediately something shifts inside me. The red earth stretches endlessly beneath leaden skies, a reminder of the deep history and continuing culture of the Kalkadoon people who have been custodians of this land for tens of thousands of years.</p><p id=\"\">It's been ten years since my time running Corrective Services programs in the Lower Gulf, working through alcohol abuse and family violence. Those three years taught me the profound importance of connection to LORE, to community, to positive identity. But returning now to Kalkadoon Country, supporting Brodie's journey, I'm struck by how much I still have to learn.</p><p id=\"\">Brodie picks me up from the airport, his energy infectious. We're here to work through his next phase of business development, supported by a Sport and Rec Queensland grant for three Camps on Country in 2025. The meeting with Sport and Rec feels like planting new seeds with strong roots. Paul Slater's presence - a respected Kalkadoon man who will mentor Brodie monthly - adds weight and wisdom to the conversation about mapping cultural protocols and partnerships.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/fce99944-d994-4ef1-b017-b5d6368ead3f/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">Walking Brodie's World</h2><p id=\"\">As we drive through Kalkadoon Country, every second car holds a friendly face calling out to Brodie. Young people gravitate to his energy, hands reaching out for high fives, voices eager to share stories. These aren't superficial connections - they're threads in a web of trust he's woven through consistent presence and genuine care.</p><h2 id=\"\">Wisdom from Uncle George</h2><p id=\"\">Sitting with Uncle George, a respected Kalkadoon elder, his words cut straight to the heart of what makes Brodie's work significant: \"All the kids know Brodie and that's a big thing. He's only young and he can go a lot further.\" As a former Police Liaison Officer and custodian of cultural knowledge, Uncle George's validation carries special weight.</p><p id=\"\">His insights about youth work come from decades of walking between worlds: \"You can't just take people out bush for a week or two and expect they're going to change. These kids, a lot of kids will take years to change.\" He speaks about the importance of targeting the right young people, especially the leaders: \"You've got to know which kids... especially around here, you've got a lot of leaders, a lot of kids that lead other kids. That's the kids you grab.\"</p><p id=\"\">His reflection on how Kalkadoon Country has changed carries deep meaning: \"When I was young here it was good here... Everyone got on. You could sleep outside, you could leave the doors open, everyone trusted anyone... Ever since the phones come in and all that, life's changed. And it's changed for the worst, not for the best.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1333px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1333px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/641a2d37-f05f-4cc6-9337-a2afe68f96f5/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">The Men's Shed: Practical Wisdom</h2><p id=\"\">At the Men's Shed, Gary's practical wisdom emerges through action rather than words. As Men's Shed Coordinator for Nook and Tardy, ourari, our children and family centre, he has created more than just a workspace - it's a sanctuary where healing happens through doing.</p><p id=\"\">The shed hums with possibility. \"We just basically do woodwork,\" Gary says with characteristic understatement, before revealing the deeper purpose. They started with pallet work, creating beds and medicine cabinets for the elderly \"where they can lock it up.\" Then came the bike program, breathing new life into cycles salvaged from Townsville's floods. \"That container at the front, that was full of bikes... Took us to get rid of all them bikes, all the kids that are walking.\"</p><p id=\"\">But it's more than just making things. The shed serves as a crucial transition point for men seeking new directions. \"We get the men from CASH, that's our diversion recovery centre. Some come out of the jail, come straight into that system,\" Gary explains. These men find their way to the shed, where they're welcomed without judgment into what Gary calls \"a real honour circle.\"The innovation in Gary's approach lies in seeing possibilities where others might see waste. The wire work program emerged from this vision - \"because you can find work wire anywhere in the community man you know.\" These creations, from totems to fencing, offer pathways to income for men rebuilding their lives.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1333px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1333px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/1df65fac-f5da-4dcf-b524-3441f7e39c92/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">Perhaps the shed's most powerful initiative was the suicide prevention march that began six years ago. \"We was the only Indigenous men in Australia to do a suicide march,\" Gary recalls with quiet pride. The impact rippled across the country, inspiring similar movements. In Mount Luby, where they lost 22 people in one month, a men's group grew from three to 250 members after following the shed's example.</p><p id=\"\">The space serves multiple purposes - a refuge (\"I'd rather you run here than stay there and bash them\"), a learning center (teaching welding and trades), and a connection point where men find purpose through practical work. Success stories emerge naturally: \"Out of the 10 years of me, I think two of them were in the mines. One's got a trade as a boilermaker, now he's flying in and flying out from Townsville.\"</p><p id=\"\">When we discuss the create bed project, Gary immediately sees its potential through the lens of community need. \"We've got a lot of homeless people down the river and that's all they is mattresses... diseases mattress material you know the scabies you know all the bed sores and everything.\" He envisions not just providing beds but teaching people to make them - \"give me a hand, make it, you know, and they can take the skill to make it.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/f4848cdc-9189-4cd0-9284-a6606d070b64/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">The shed's latest project, the Red Benches initiative, exemplifies their approach to complex community issues. Working with young people from T2S and Flexi school, they're creating visible symbols of domestic violence awareness while teaching practical skills. \"We made them and the women painted them and they did the artwork on them... it was a joint venture with the men, you know, for DV.\"</p><p id=\"\">In Gary's world, every project serves multiple purposes - teaching skills, building confidence, creating practical solutions, and weaving stronger community connections. As he says, \"Sometimes you don't have to do the cultural stuff. You can just sit down and yarn and listen, really.\" It's in this space of doing and being together that real change takes root.This practical wisdom offers a powerful model for community development - one where healing happens through purposeful action, where skills transfer naturally through shared work, and where every project strengthens the web of community connection.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/91cd3ebd-308e-4cce-ae2d-32c280ec59bc/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">Seeds of Change: The Create Bed Adventure</h2><p id=\"\">What began as disappointment at Bunnings - no crates available for our bed project - transformed into a journey of community connection. Gary at the Men's Shed pointed us toward Good Shepherd Church, where an unexpected reunion with Aunty Dolly. A decade dissolves in an instant. Aunty Dolly, who once helped countless community members return to Country for sorry business and health-related trips, opens the door. Her initial uncertainty breaks into recognition, and suddenly we're connected across time. These are the moments that remind me of the deep relationships that hold communities together.led to our first breakthrough. Her immediate response of \"just go for it\" when hearing about the create bed idea opened the first door. </p><p id=\"\">The next day, after checking with Father Mick who directed us to Coles, we found ourselves negotiating for crates - initially just borrowing them with a promise to return. In true community spirit, we ended up giving back more than we borrowed, turning a temporary loan into a gift that kept giving.</p><p id=\"\">The real magic happened in the building. With Mark, the experience transcended simple furniture construction. Here was a man who'd been sleeping on a bed frame with just a piece of wood the night before. Working alongside Brodie and other men who trust and support him, we created more than just a bed - we built connection, dignity, and possibility. Mark's quiet pride in having a create bed \"for as long as he wants\" spoke volumes about the project's deeper impact.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/e0066498-0364-4b60-a5a0-3d2fe0b29a18/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/96c3cff0-0fa1-4ead-8038-8cf0e823e410/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">The energy continued in Pioneer, where we turned bed-building into a family event. A 13-year-old lad joined the assembly team while family members kept time, turning work into play. Watching the bed rise on the balcony, becoming a play space for all the kids, showed how these simple creations could serve multiple purposes - practical solution, community activity, and source of joy.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/3d7a5b74-7073-4745-ad56-99f6d6198241/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">These moments of collaborative creation proved what Gary and Uncle George had been saying about real community work. It wasn't about formal programs or bureaucratic processes - it was about practical action that brings people together, solving immediate needs while building relationships and skills.</p><p id=\"\">The create bed journey became a perfect example of how solutions emerge through community connection - from Gary's guidance to Aunty Dolly's blessing, from borrowed crates to shared labor, from addressing immediate needs to creating spaces for play and dignity. Each bed built strengthened the web of relationships that make community change possible.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/eb94a438-a285-47a7-b653-639f87dcc4c2/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">‍</p><h2 id=\"\">Learning from Doomadgee Visitors</h2><p id=\"\">At the river bed, we meet a couple from Doomadgee. Their quiet presence carries decades of wisdom. Testing the create bed, their responses are measured but meaningful. \"Nothing like this,\" they say, comparing it to the springy mattresses available in their community for $180. Their approval is simple but profound: \"The best.\"</p><p id=\"\">Their guidance about community engagement teaches me about proper protocols. When I ask about visiting Doomadgee, their answer is clear: \"You can ask the Council, and that'll help you and then talk to the community and all that.\" This is the way - no shortcuts, no assumptions, respect for proper channels and community leadership.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/d992efb0-73d0-4377-8594-df4cc1dc029d/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">Aunty Joan's Sacred Knowledge</h2><p id=\"\">Sitting with Aunty Joan becomes one of the week's most profound moments. Her insistence on not being recorded speaks to the sanctity of story. Instead, she shares her carefully preserved workbooks, self-taught writing alongside precious photos that document a life lived close to country.</p><p id=\"\">She shows us images that tell the story of colonisation - how it tried to define what they could do, how life was supposed to work, how it attempted to limit their way of living on the land. Her stories of driving sheep at 14, her working history, her ability to carve a beast, and her deep connection to cooking on country with family aren't just memories - they're vital knowledge at risk of being lost.</p><p id=\"\">Her concern about cultural disconnection cuts deep: \"A young person would not be able to pick out the bush that you smoke to help a mother's lactation after pregnancy.\" She sees how the modern world is disconnecting young people from the LORE that for so many years helped them understand life at a different level, supported a community of people helping each other and caring for the land.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/fcc91f92-4cf0-47d3-ad1c-a150e0968a11/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1333px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1333px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/7c8f93c5-0f20-43d7-a54e-0949e7c7558f/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/628df48b-5e9a-4b9d-b7a2-681e6fdae835/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">Brodie's Growing Impact</h2><p id=\"\">Throughout the week, we witness Brodie's natural leadership in action. At the Flexi school on Kalkadoon Country, young people flock to him, eager for connection. The teachers implore him to come more often, to create programs that mentor youth, connect them to the gym, and then guide them on country.</p><p id=\"\">Uncle George's words about Brodie's potential resonate: \"He's on the right track. But he's trying to do it himself too, like I do. And that's the thing. When you're trying to do things by yourself, it's very hard to change. If you've got another four Brodies or four of me or something, it's going to make things a lot easier.\"</p><h2 id=\"\">The Complex Reality</h2><p id=\"\">Kalkadoon Country holds its contradictions openly. The billions generated by the mines cast long shadows over community poverty. At the river bed, people sleep on old mattresses and work through their trauma with wine bags and cartons of beer. Young people walk streets instead of attending school.</p><p id=\"\">Yet hope grows in unexpected places - in the Men's Shed's quiet work, in Aunty Joan's careful preservation of stories, in Brodie's dedicated presence with youth. As Uncle George says, \"You can stop it, I tell you right now, if you get a group of good people together.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/88fab1eb-d3b6-4eef-b153-23b2ae72dcf8/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">A Personal Reflection</h2><p id=\"\">As I prepare to leave Kalkadoon Country, I'm humbled by how much I still have to learn. Most of the time when I talk about community work, I hear white people telling me what it's like in community, how I should act, what happened to them and what I need to do. I still don't know how to take this, but I stay quiet and continue to learn on country from elders, Traditional Owners and community.</p><p id=\"\">I feel privileged that people have opened their worlds to me across many traditional lands - from Bwgcolman (Palm Island, where many tribal groups were forcibly relocated, with Manbarra people as traditional owners), to Minjerribah (Stradbroke Island, home of the Quandamooka people), to Mparntwe (Alice Springs, home of the Arrernte people), and here on Kalkadoon Country. In each place, people have shown me protocols, walked me through ceremony and spent deep time talking through ideas and opportunities.</p><p id=\"\">The contrast here on Kalkadoon Country is stark - between the billions of dollars generated from mining on traditional lands and the poverty visible in parts of the community. At the river bed, people sleep on old mattresses and work through their trauma. Young people walk the streets rather than being at school. The privileged community looks down on issues that are in their face, not sure how to take action.</p><p id=\"\">Through A Curious Tractor, Nic and I remain deeply curious to know more while standing with community in developing, trialing and testing solutions. There will be times we get it wrong. People might growl at us. Many will disagree. But what we have are strong local people leading us in the right ways, building our understanding.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/1fd3d794-6012-4b9f-95d3-1cbe842cca1c/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">I don't seek acceptance - that's not what this work is about. I want to offer my skills, do things with community, help when asked, and work through things I don't know. I want to walk alongside people when welcome and try to tell this story of hope, resilience and connection to Mother Earth that too many people have lost.</p><p id=\"\">I believe Indigenous thinking offers a way through many of the issues we face in this generation. When Aunty Joan speaks of traditional medicines, when Uncle George talks about community responsibility, when the couple from Doomadgee quietly demonstrate proper protocols - these are not just stories or rules, they're pathways to healing that have sustained people for tens of thousands of years.</p><p id=\"\">I want to share that thinking in the hope some will listen and reconnect with nature in the way that First Nations peoples have done since time immemorial. As Uncle George says, \"If you speak from the heart and you tell, and you say the right things and you speak the truth, people listen.\"</p><p id=\"\">Standing here on Kalkadoon Country, watching Brodie work with young people, seeing the elders share their wisdom, witnessing the quiet strength of community connections, I understand more deeply than ever that our role is to listen first, to learn always, and to walk alongside when invited. The solutions aren't in grand gestures or outside expertise - they're in the patient work of supporting community-led change, one relationship at a time.</p><p id=\"\">In the end, it's about understanding that every traditional Country holds its own wisdom, its own protocols, its own ways of healing. Our job isn't to bring solutions, but to support the knowledge and leadership that already exists in community, while remaining humble enough to keep learning, growing, and changing ourselves.</p><p id=\"\">As I board the plane to leave, I carry these lessons with me, knowing they'll continue to teach long after this visit ends. The privilege of being welcomed into these spaces comes with responsibility - to listen well, to support wisely, and to share stories in ways that honour their depth and complexity.</p><p id=\"\">‍</p>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": null,
-      "relatedProjects": [],
-      "relatedProjectSlugs": [],
-      "publishedAt": "2026-03-25T22:45:19.558574+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": "https://empathyledger.com/api/media/fce99944-d994-4ef1-b017-b5d6368ead3f/file",
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 15,
-        "videoCount": 0,
-        "photoPreviews": [
-          {
-            "url": "https://empathyledger.com/api/media/fce99944-d994-4ef1-b017-b5d6368ead3f/file",
-            "title": null,
-            "alt_text": null
-          },
-          {
-            "url": "https://empathyledger.com/api/media/641a2d37-f05f-4cc6-9337-a2afe68f96f5/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/1df65fac-f5da-4dcf-b524-3441f7e39c92/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/f4848cdc-9189-4cd0-9284-a6606d070b64/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/91cd3ebd-308e-4cce-ae2d-32c280ec59bc/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/e0066498-0364-4b60-a5a0-3d2fe0b29a18/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/96c3cff0-0fa1-4ead-8038-8cf0e823e410/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/3d7a5b74-7073-4745-ad56-99f6d6198241/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          }
-        ],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/seeds-of-change-walking-with-elders-and-youth-on-kalkadoon-country",
-      "localPath": "/stories/seeds-of-change-walking-with-elders-and-youth-on-kalkadoon-country",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "6a15b4ea-2e88-419e-a345-cebe07406c25",
-      "title": "The Spirit Must Be Strong",
-      "slug": "the-spirit-must-be-strong",
-      "subtitle": null,
-      "excerpt": "Through his work with Palm Island's rangers, Richard Cassidy shows how meaningful change happens when young people find their identity through both cultural connection and purposeful action - creating transformation that moves at the speed of ceremony rather than commerce.",
-      "content": "<p id=\"\">\"Sometimes when you're at the coalface, it's really hard to look up because you get the dust in your eyes, and you get the dust in your lungs and it's hard to breathe.\" Richard Cassidy pauses, reflecting on the daily challenges of creating change on Palm Island. \"But then you get some sound bites from people in the community or an elder, and they go 'oh yeah, really well like what you're doing,' and now I go, oh gosh, that's gold. I absolutely needed to hear that.\"</p><p id=\"\">This interplay between the grinding reality of daily work and moments of affirmation characterizes the path of transformation on Palm Island. As Richard notes, \"for every good moment, there's probably 10, 15, 20 not so good moments.\" Yet it's these glimpses of progress that fuel the journey forward.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/b915ea80-ff34-43db-b3a6-25431ab6083a/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><p id=\"\">At the heart of Richard's philosophy is a profound understanding of identity and being. \"For some people, they're doing people - they get their identity out of what they do,\" he explains. \"For others, when I call our mob, we're being people. We be, to sit and to be, and it's about occupying a place or a space in relationship to family or to country.\" This distinction illuminates the challenge faced by many in the community: \"Straight away if you haven't got a job or something like that, and you're unemployed, straight away you're on the left foot. And you go, 'well, I might be unemployed.' And that takes away from who you might be.\"</p><p id=\"\">This understanding shapes his approach to community renewal: \"How do we go from a place of brokenness where it's really hard to find who you might be because you've been displaced,\" he asks, \"to a place where you are who you are, and you know who you might be, and then you participate in that place by what you're doing?\"</p><p id=\"\">Leading the MinggaMingga Rangers program, Richard has developed an approach that nurtures both being and doing. \"For the last 18 months to two years, I've been banging on with my team and going, 'OK, I need you to shine because if you shine, I'll look good.' But in order for them to shine, they need a whole bunch of things like encouragement and to be able to be listened to and to know where they're coming from.\"</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/239aaf32-6b45-4a10-8d2a-fb7b50eb7747/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><p id=\"\">The results manifest in quiet but powerful ways. \"I could almost taste it every now and then,\" he says, \"especially in some of the eyes of these lads when they jump in the ute and they're gone. You go, 'yep, okay.' But they come back and they're sweating and they're talking about what they've done and how excited they are.\"</p><p id=\"\">Perhaps most significantly, Richard articulates a vision of cultural synthesis that neither clings rigidly to the past nor abandons it entirely. He describes it as two edges of a spear - traditional law on one side, mainstream obligations on the other. \"We're not going to say 'let's throw that one away, let's throw this one away,' but we're going to actually use each to inform the operation of what we do. And that'll sharpen our spear.\"</p><p id=\"\">This approach requires careful discernment about what to \"adopt, adapt, or abandon\" - a framework passed down by Elder Uncle Graham. It's a path that demands both wisdom and courage, as illustrated by one of Richard's rangers who chose to miss sorry business to fulfill work commitments - \"an absolute huge call,\" as Richard acknowledges, but one that reflected a deeper commitment to \"push forward\" for the community's future.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1333px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1333px\"><div><img src=\"https://empathyledger.com/api/media/49aed131-9bad-480c-be08-7fcaf8a60520/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/c9eb82c5-eead-4c49-9641-b77280cc1cf5/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><p id=\"\">Looking at Palm Island's trajectory, Richard sees hope in the emerging generation: \"If we look at the history of Palm... to then see a small remnant of their descendants rising out of the dust of that history and just owning a space of semi-independence and autonomy and with a space of creativity and purpose and fire and energy - then you're going to go, oh yeah, there's something different about this little team.\"</p><p id=\"\">This vision - of a community rising from historical dust with both fire and purpose, maintaining cultural strength while engaging with modern challenges - drives the daily work at the coalface. \"I'm hoping that little team will actually then grow into a bigger team,\" Richard reflects, \"and be able to almost produce a wave or a movement of change for this place.\"</p><p id=\"\">Even as he acknowledges the weight of expectation on the ranger program and the broader community, Richard's perspective remains grounded in hope and practical action. Like the traditional protocols that guide their work - from Welcome to Country ceremonies to cultural burning practices - the path forward moves at the speed of ceremony, not commerce. It's a journey of reconnection, of finding strength in who you are before focusing on what you do, of building capability while preserving culture.</p><p id=\"\">In this way, every day at the coalface becomes part of a larger story of transformation - dust in the eyes, yes, but also golden moments of community recognition, young people finding their purpose, and a culture being renewed through meaningful work on country.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:4000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"4000px\"><div><img src=\"https://empathyledger.com/api/media/94bee575-ca10-4bd6-a158-a4b90eab928b/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><p id=\"\">‍</p>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": null,
-      "relatedProjects": [],
-      "relatedProjectSlugs": [],
-      "publishedAt": "2026-03-25T22:45:19.558574+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": "https://empathyledger.com/api/media/b915ea80-ff34-43db-b3a6-25431ab6083a/file",
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 5,
-        "videoCount": 0,
-        "photoPreviews": [
-          {
-            "url": "https://empathyledger.com/api/media/b915ea80-ff34-43db-b3a6-25431ab6083a/file",
-            "title": null,
-            "alt_text": null
-          },
-          {
-            "url": "https://empathyledger.com/api/media/239aaf32-6b45-4a10-8d2a-fb7b50eb7747/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/49aed131-9bad-480c-be08-7fcaf8a60520/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/c9eb82c5-eead-4c49-9641-b77280cc1cf5/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/94bee575-ca10-4bd6-a158-a4b90eab928b/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          }
-        ],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/the-spirit-must-be-strong",
-      "localPath": "/stories/the-spirit-must-be-strong",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "320a2d56-56ee-4f88-84ab-ef983e97975a",
-      "title": "The Reintegration Puzzle Story Portal",
-      "slug": "the-reintegration-puzzle-story-portal",
-      "subtitle": null,
-      "excerpt": "This remodelled pay phone, debuting at the Reintegration Puzzle Conference in Sydney, is designed to reshape narratives around reintegration and foster meaningful connections between conference participants, organisers and the community.",
-      "content": "<h3 id=\"\"><strong id=\"\">A Remodelled Pay Phone to Bridge Gaps and Foster Understanding</strong></h3><p id=\"\">This remodelled pay phone, debuting at the Reintegration Puzzle Conference in Sydney, is designed to reshape narratives around reintegration and foster meaningful connections between conference participants, organisers and the community.</p><h3 id=\"\"><strong id=\"\">How It Works</strong></h3><ul id=\"\"><li id=\"\"><strong id=\"\">Pick Up the Receiver:</strong> Engage with the phone as you would with any pay phone.</li><li id=\"\"><strong id=\"\">Leave a Message:</strong> Share your thoughts about the conference, tell a story, or offer words of support.</li><li id=\"\"><strong id=\"\">Secure and Confidential:</strong> Your messages are recorded securely, ensuring your privacy.</li></ul><h3 id=\"\"><strong id=\"\">What to do</strong></h3><ul><li id=\"\"><strong id=\"\">Pick up the receiver.</strong></li><li id=\"\"><strong id=\"\">Breathe deeply.</strong></li><li id=\"\"><strong id=\"\">Count to ten.</strong></li><li id=\"\"><strong id=\"\">Leave your message.</strong></li></ul><p id=\"\">The Story Portal is more than a communication tool. It's a platform for challenging and changing negative perceptions surrounding reintegration by sharing their stories of growth and rehabilitation.</p><p id=\"\">‍</p>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": null,
-      "relatedProjects": [],
-      "relatedProjectSlugs": [
-        "justicehub"
-      ],
-      "publishedAt": "2026-03-25T22:45:19.558574+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": null,
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 0,
-        "videoCount": 0,
-        "photoPreviews": [],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/the-reintegration-puzzle-story-portal",
-      "localPath": "/stories/the-reintegration-puzzle-story-portal",
       "syndicationDestinations": [
         "act_el"
       ]
@@ -627,8 +386,8 @@
       "title": "Oonchiumpa: What Happens When Community Leads",
       "slug": "oonchiumpa-what-happens-when-community-leads",
       "subtitle": null,
-      "excerpt": "<p><em>There is a version of this story told through numbers. It has its place. But numbers are a translation, and something always gets lost in the translation. This is the fuller version.</em></p><h...",
-      "content": "<p><em>There is a version of this story told through numbers. It has its place. But numbers are a translation, and something always gets lost in the translation. This is the fuller version.</em></p><hr><h2>The cost of a cell</h2><p>Australia spends somewhere north of $1.3 million each year to hold one young person in detention. In the Northern Territory, it costs more. The reoffending rate sits above 80 per cent. Indigenous young people make up more than 60 per cent of those detained.</p><p>Think of it like a leaky bucket. The system keeps filling it. Nobody has stopped to ask why the bucket keeps emptying.</p><p>In Alice Springs, a small organisation decided to ask the question.</p><hr><h2>Who They Are</h2><p>Oonchiumpa is 100 per cent Aboriginal community-controlled. It was founded by two women from Central Australia, and that origin matters more than it might first seem.</p><p>Kristy Bloomfield is a Central Arrernte, Eastern Arrernte and Alyawarra woman, a Traditional Owner of Mparntwe, Alice Springs. She grew up in the town that she now works to change. She carries, in her own words, the stories of sacred sites and burial grounds that only her family would know. Her grandfather, a stolen generation man taken from his parents to the Bungalow in Alice Springs, went to extraordinary lengths to keep his children from the same fate, marrying Kristy's grandmother in a church in Tennant Creek after police threatened to take the children away. The history she carries is not abstract. It is personal and it is living.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/15f96ab0-b8ee-4bdd-810e-73d9c55e2dba/file\" alt=\"IMG_3190.jpg\"><p>Tanya Turner is an Eastern Arrernte woman. She took a law degree at the University of Western Australia, worked as an associate at the Supreme Court of Victoria, ran a family mediation practice with a 95 per cent resolution rate, and then, one day on a tram in Melbourne, felt the pull home. She resigned two weeks later. That impulse, to bring expertise back where it belongs, is the architecture of Oonchiumpa.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/04117401-31b1-492d-becb-ee5b7dba2bb3/file\" alt=\"IMG_3459.jpg\"><p>Together they run four programs that operate like concentric circles: direct relationship with young people at the centre, cultural authority extending outward, the broader system at the edges.</p><hr><h2>Why This Works When Other Things Don't</h2><p>The clearest way to describe Oonchiumpa's model is to describe what it is not.</p><p>Most youth interventions are designed at a distance and delivered locally. They treat young people as recipients. They measure outputs. When the relationship gets hard, they document it and move on.</p><p>Oonchiumpa operates from a different premise: that the young people they work with already know their world, that they have capability the system rarely recognises, and that the most effective thing an adult can do is stay present when the pressure is highest.</p><p>Fred Campbell is a youth case worker who married into the Bloomfield family. He describes his role in simple terms. He does case planning. He runs care team meetings. He gives young people rides to school. He shows up.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/747f8f52-2f89-4706-b6a8-0f80d4b1e442/file\" alt=\"\"><p>He told us about Xavier, one of Oonchiumpa's first clients, who has a disability. When Xavier's relationship with other service providers became difficult, those services created distance. Fred uses that word, \"distanced,\" in a way that says everything about how those institutions saw their role. Oonchiumpa stayed.</p><p>Xavier was recently released from detention. He has not been back in trouble. He built a Stretch Bed from recycled plastic, the kind of portable, durable bed that Fred notes has immediate use in community: for ceremony business, for bush trips, for sleeping off the ground away from the dogs that carry scabies, for families practising sorry business who need to move away from a place after a death.</p><p>\"He just was so proud showing them that he can build it,\" Fred said. \"He's quite capable of building that on his own and sharing that onto other kids.\"</p><p>The reports on Xavier's \"ability to understand\" had said otherwise. Xavier had a different version of his own capability. Oonchiumpa bet on his version.</p><p>This is not a complicated idea. It is, however, a rare one.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/c25062c3-8261-4868-b8a3-f321d3f37140/file\" alt=\"\"><hr><h2>The Young People</h2><p>We spent time with young people connected to Oonchiumpa. Not to extract quotes for a report, but to listen to what they actually said.</p><p>J is fourteen. He lives with his grandfather at Upper Camp. He likes basketball. He has been inside the Alice Springs Detention Centre.</p><p>Asked what detention is like, he said: \"At six o'clock you get locked down. You wait till tomorrow.\"</p><p>Asked what would stop him getting into trouble: \"Looking after my family.\"</p><p>That is not the answer the justice system is designed around. It is probably the most important answer in this story.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/6504f272-6aa4-452b-ba34-0893b5d690cf/file\" alt=\"1E5A2170.jpg\"><p>N is fourteen. He lives at a station in Double Camp. He goes to school. He wants to play AFL. He knows, with the clarity of someone who has worked it out himself, that going to school every day is the path to that. What he lacked was not motivation. He lacked someone to walk the path with him. Oonchiumpa picks him up, takes him to school, takes him to the cinema. The thing on offer is consistency. The consistency is the program.</p><p>L is sixteen. She lives with her auntie and manages a complex home situation with a kind of steadiness that would be remarkable in someone twice her age. She was sent to Darwin Youth Detention, 1,500 kilometres from Alice Springs. She was allowed twelve-minute phone calls, with two-hour waits between them.</p><p>\"I don't like going to Darwin because I have no family there.\"</p><p>When asked why young people get into trouble, she answered in one word: \"Oppression.\"</p><p>These three young people, across different conversations, all named the same thing as the most painful part of detention. Not the loss of freedom. The loss of family. None of them described their home situations as simple or easy. None of them said they wanted to leave. They said that is home, and home should be safer, not replaced.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/1c3cf2a2-7d67-4f1f-a2c2-8b7c43a9e37b/file\" alt=\"1E5A2229.jpg\"><hr><h2>What the Numbers Point To</h2><p>When NT Police ran Operation Luna, a targeted response to twenty-one high-risk young people in Alice Springs, Oonchiumpa worked alongside them. By December, twenty of those twenty-one young people were off the list.</p><p>Across Oonchiumpa's work: 95 per cent diversion from the justice system. 72 per cent of young people who had disengaged from school have returned to education. The organisation runs at 97.6 per cent less cost than detaining one child for one year.</p><p>These are not offered as proof that the model is finished or scalable on its own terms. They are offered as evidence that the underlying theory, that relationship, cultural authority and practical support produce better outcomes than detention, is not wishful thinking.</p><hr><h2>What Comes Next</h2><p>In June 2026, eight Oonchiumpa staff will travel to South East Queensland to visit other community organisations, share approaches and build relationships. The model is designed to travel.</p><p>The partnership with Professor Helen Milroy and the Australian National University continues to expand, training law students, future magistrates and policymakers in restorative justice approaches grounded in First Nations knowledge. The goal, as Tanya Turner puts it, is not just to serve Alice Springs better. It is to demonstrate what is possible when Aboriginal people with cultural authority are given the resources to lead.</p><p>Atnarpa Homestead, on country east of Alice Springs belonging to Max Bloomfield's family, provides the ground for on-country cultural camps. Young people go out to country, work with Elders and Traditional Owners, and return to something that is harder to name than a program outcome but that Fred, and Kristy, and Tanya, all point to as foundational: knowing who you are, knowing where you come from, knowing who your family is.</p><hr><h2>The Question Underneath All Of This</h2><p>Tanya Turner said something in a conversation that has stayed with us.</p><p>\"Our young people are just collateral in a bigger issue. The issue doesn't sit with them. It sits on a much broader level and with adults, not with children.\"</p><p>The system was built to manage consequences. Oonchiumpa is trying to address causes. That is a different kind of work, and it requires a different kind of authority than the system currently offers community-led organisations.</p><p>Xavier built a bed. J wants to look after his grandfather. N wants to play football. L named the root cause in one word.</p><p>The alternative to detention is not theoretical. It is already happening. In Alice Springs, it is called Oonchiumpa.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/7cfe3601-774a-49d9-a6f7-9be39ee6264b/file\" alt=\"\"><hr><p><em>Young people's stories are drawn from Empathy Ledger transcripts with consent protocols in place. Names used with permission and initials when under 18. Detention cost data sourced from the Productivity Commission Report on Government Services (ROGS), Table 17A.20.</em></p>",
+      "excerpt": "There is a version of this story told through numbers. It has its place. But numbers are a translation, and something always gets lost in the translation. This is the fuller version.",
+      "content": "<p><em>There is a version of this story told through numbers. It has its place. But numbers are a translation, and something always gets lost in the translation. This is the fuller version.</em></p><hr><h2>The cost of a cell</h2><p>Australia spends somewhere north of $1.3 million each year to hold one young person in detention. In the Northern Territory, it costs more. The reoffending rate sits above 80 per cent. Indigenous young people make up more than 60 per cent of those detained.</p><p>Think of it like a leaky bucket. The system keeps filling it. Nobody has stopped to ask why the bucket keeps emptying.</p><p>In Alice Springs, a small organisation decided to ask the question.</p><hr><h2>Who They Are</h2><p>Oonchiumpa is 100 per cent Aboriginal community-controlled. It was founded by two women from Central Australia, and that origin matters more than it might first seem.</p><p>Kristy Bloomfield is a Central Arrernte, Eastern Arrernte and Alyawarra woman, a Traditional Owner of Mparntwe, Alice Springs. She grew up in the town that she now works to change. She carries, in her own words, the stories of sacred sites and burial grounds that only her family would know. Her grandfather, a stolen generation man taken from his parents to the Bungalow in Alice Springs, went to extraordinary lengths to keep his children from the same fate, marrying Kristy's grandmother in a church in Tennant Creek after police threatened to take the children away. The history she carries is not abstract. It is personal and it is living.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/15f96ab0-b8ee-4bdd-810e-73d9c55e2dba/file\" alt=\"IMG_3190.jpg\"><p>Tanya Turner is an Eastern Arrernte woman. She took a law degree at the University of Western Australia, worked as an associate at the Supreme Court of Victoria, ran a family mediation practice with a 95 per cent resolution rate, and then, one day on a tram in Melbourne, felt the pull home. She resigned two weeks later. That impulse, to bring expertise back where it belongs, is the architecture of Oonchiumpa.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/04117401-31b1-492d-becb-ee5b7dba2bb3/file\" alt=\"IMG_3459.jpg\"><p>Together they run four programs that operate like concentric circles: direct relationship with young people at the centre, cultural authority extending outward, the broader system at the edges.</p><hr><h2>Why This Works When Other Things Don't</h2><p>The clearest way to describe Oonchiumpa's model is to describe what it is not.</p><p>Most youth interventions are designed at a distance and delivered locally. They treat young people as recipients. They measure outputs. When the relationship gets hard, they document it and move on.</p><p>Oonchiumpa operates from a different premise: that the young people they work with already know their world, that they have capability the system rarely recognises, and that the most effective thing an adult can do is stay present when the pressure is highest.</p><p>Fred Campbell is a youth case worker who married into the Bloomfield family. He describes his role in simple terms. He does case planning. He runs care team meetings. He gives young people rides to school. He shows up.</p><p>He told us about Xavier, one of Oonchiumpa's first clients, who has a disability. When Xavier's relationship with other service providers became difficult, those services created distance. Fred uses that word, \"distanced,\" in a way that says everything about how those institutions saw their role. Oonchiumpa stayed.</p><p>Xavier was recently released from detention. He has not been back in trouble. He built a Stretch Bed from recycled plastic, the kind of portable, durable bed that Fred notes has immediate use in community: for ceremony business, for bush trips, for sleeping off the ground away from the dogs that carry scabies, for families practising sorry business who need to move away from a place after a death.</p><p>\"He just was so proud showing them that he can build it,\" Fred said. \"He's quite capable of building that on his own and sharing that onto other kids.\"</p><p>The reports on Xavier's \"ability to understand\" had said otherwise. Xavier had a different version of his own capability. Oonchiumpa bet on his version.</p><p>This is not a complicated idea. It is, however, a rare one.</p><hr><h2>The Young People</h2><p>We spent time with young people connected to Oonchiumpa. Not to extract quotes for a report, but to listen to what they actually said.</p><p>J is fourteen. He lives with his grandfather at Upper Camp. He likes basketball. He has been inside the Alice Springs Detention Centre.</p><p>Asked what detention is like, he said: \"At six o'clock you get locked down. You wait till tomorrow.\"</p><p>Asked what would stop him getting into trouble: \"Looking after my family.\"</p><p>That is not the answer the justice system is designed around. It is probably the most important answer in this story.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/6504f272-6aa4-452b-ba34-0893b5d690cf/file\" alt=\"1E5A2170.jpg\"><p>N is fourteen. He lives at a station in Double Camp. He goes to school. He wants to play AFL. He knows, with the clarity of someone who has worked it out himself, that going to school every day is the path to that. What he lacked was not motivation. He lacked someone to walk the path with him. Oonchiumpa picks him up, takes him to school, takes him to the cinema. The thing on offer is consistency. The consistency is the program.</p><p>L is sixteen. She lives with her auntie and manages a complex home situation with a kind of steadiness that would be remarkable in someone twice her age. She was sent to Darwin Youth Detention, 1,500 kilometres from Alice Springs. She was allowed twelve-minute phone calls, with two-hour waits between them.</p><p>\"I don't like going to Darwin because I have no family there.\"</p><p>When asked why young people get into trouble, she answered in one word: \"Oppression.\"</p><p>These three young people, across different conversations, all named the same thing as the most painful part of detention. Not the loss of freedom. The loss of family. None of them described their home situations as simple or easy. None of them said they wanted to leave. They said that is home, and home should be safer, not replaced.</p><img class=\"rounded-lg max-w-full mx-auto my-8\" src=\"https://empathyledger.com/api/media/1c3cf2a2-7d67-4f1f-a2c2-8b7c43a9e37b/file\" alt=\"1E5A2229.jpg\"><hr><h2>What the Numbers Point To</h2><p>When NT Police ran Operation Luna, a targeted response to twenty-one high-risk young people in Alice Springs, Oonchiumpa worked alongside them. By December, twenty of those twenty-one young people were off the list.</p><p>Across Oonchiumpa's work: 95 per cent diversion from the justice system. 72 per cent of young people who had disengaged from school have returned to education. The organisation runs at 97.6 per cent less cost than detaining one child for one year.</p><p>These are not offered as proof that the model is finished or scalable on its own terms. They are offered as evidence that the underlying theory, that relationship, cultural authority and practical support produce better outcomes than detention, is not wishful thinking.</p><hr><h2>What Comes Next</h2><p>In June 2026, eight Oonchiumpa staff will travel to South East Queensland to visit other community organisations, share approaches and build relationships. The model is designed to travel.</p><p>The partnership with Professor Helen Milroy and the Australian National University continues to expand, training law students, future magistrates and policymakers in restorative justice approaches grounded in First Nations knowledge. The goal, as Tanya Turner puts it, is not just to serve Alice Springs better. It is to demonstrate what is possible when Aboriginal people with cultural authority are given the resources to lead.</p><p>Atnarpa Homestead, on country east of Alice Springs belonging to Max Bloomfield's family, provides the ground for on-country cultural camps. Young people go out to country, work with Elders and Traditional Owners, and return to something that is harder to name than a program outcome but that Fred, and Kristy, and Tanya, all point to as foundational: knowing who you are, knowing where you come from, knowing who your family is.</p><hr><h2>The Question Underneath All Of This</h2><p>Tanya Turner said something in a conversation that has stayed with us.</p><p>\"Our young people are just collateral in a bigger issue. The issue doesn't sit with them. It sits on a much broader level and with adults, not with children.\"</p><p>The system was built to manage consequences. Oonchiumpa is trying to address causes. That is a different kind of work, and it requires a different kind of authority than the system currently offers community-led organisations.</p><p>Xavier built a bed. J wants to look after his grandfather. N wants to play football. L named the root cause in one word.</p><p>The alternative to detention is not theoretical. It is already happening. In Alice Springs, it is called Oonchiumpa.</p><hr><p><em>Young people's stories are drawn from Empathy Ledger transcripts with consent protocols in place. Names used with permission and initials when under 18. Detention cost data sourced from the Productivity Commission Report on Government Services (ROGS), Table 17A.20.</em></p>",
       "authorName": "Benjamin Knight",
       "authorBio": null,
       "articleType": "story_feature",
@@ -649,11 +408,11 @@
         "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
         "slug": "benjamin-knight",
         "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
+        "avatarUrl": null,
         "bio": null
       },
       "media": {
-        "photoCount": 8,
+        "photoCount": 5,
         "videoCount": 0,
         "photoPreviews": [
           {
@@ -672,16 +431,6 @@
             "alt_text": "IMG_3459.jpg"
           },
           {
-            "url": "https://empathyledger.com/api/media/747f8f52-2f89-4706-b6a8-0f80d4b1e442/file",
-            "title": null,
-            "alt_text": null
-          },
-          {
-            "url": "https://empathyledger.com/api/media/c25062c3-8261-4868-b8a3-f321d3f37140/file",
-            "title": null,
-            "alt_text": null
-          },
-          {
             "url": "https://empathyledger.com/api/media/6504f272-6aa4-452b-ba34-0893b5d690cf/file",
             "title": null,
             "alt_text": "1E5A2170.jpg"
@@ -690,162 +439,17 @@
             "url": "https://empathyledger.com/api/media/1c3cf2a2-7d67-4f1f-a2c2-8b7c43a9e37b/file",
             "title": null,
             "alt_text": "1E5A2229.jpg"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/7cfe3601-774a-49d9-a6f7-9be39ee6264b/file",
-            "title": null,
-            "alt_text": null
           }
         ],
         "videoPreviews": []
       },
       "ctas": [],
       "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/oonchiumpa-what-happens-when-community-leads",
+      "canonicalUrl": "https://empathyledger.com/articles/oonchiumpa-what-happens-when-community-leads",
       "localPath": "/stories/oonchiumpa-what-happens-when-community-leads",
       "syndicationDestinations": [
         "act_el",
         "act_oo"
-      ]
-    },
-    {
-      "id": "8ea6d576-a9a1-4df8-8e54-0f44de2bce92",
-      "title": "At the Speed of Ceremony: Learning Partnership on Palm Island",
-      "slug": "at-the-speed-of-ceremony-learning-partnership-on-palm-island",
-      "subtitle": null,
-      "excerpt": "This story captures a transformative journey to Palm Island, where the process of building beds becomes a powerful metaphor for community connection, cultural respect, and regeneration.",
-      "content": "<figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:8192px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"8192px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/8c9860bb-4a0b-4706-8516-a6903dc81968/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Palm Island from the air on a sunrise trip with Richard Cassidy Day 2</em></strong></figcaption></figure><p id=\"\">The journey began in Melbourne's pre-dawn stillness, marking the end of a week-and-a-half traveling with the AIME troupe from Sydney. Over coffee with Willow from Regen Network, we spun possibilities around Australia's story of place—how regeneration and local knowledge might intertwine to create something new, yet anchored in ancient wisdom.</p><p id=\"\">Brisbane offered a brief but essential pause with family. We shared food, stories, and laughter. I offered gifts, small tokens of respect for their patience as I traverse Australia, connecting with communities. The privilege of such a supportive family isn't lost on me—it’s both a blessing and a responsibility.</p><p id=\"\">Arriving in Townsville at 4:15pm, I was thrust into a race against time. The car hire system was down (30 minutes lost), Bunnings couldn’t find the crates (another 20 minutes), and Kmart became a blur of mattress protectors and squeaky trolley wheels. At 5:55pm, success—the crates were finally loaded into the ute. After a quick dip at the hotel, I collected Nic from the airport, our new mattress topper from Zinus in hand. We fell asleep thinking of the ten beds waiting to be built with Palm Island’s community members.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1068px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1068px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/01b87716-ffbf-43e6-a2cc-e78150f1bee1/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Creates and the ute</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:808px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"808px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/8ea5d93b-e148-4945-a154-a4d4573e940f/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">All loaded up with mattress protectors and creates</em></strong></figcaption></figure><p id=\"\">The flight over to Palm Island revealed the landscape like a painting—coral glinting beneath clear waters, lush greenery, and waves softly brushing the shore. I felt the weight of the journey as I lugged my bag toward Butler Bay, hoping to find an Orange Sky shift that wasn’t there. With no phone service, I trekked back to the airport, sweaty but laughing, eventually catching a ride with the CDP crew into town.</p><p id=\"\">When Nic arrived on the barge with the crates, we hit the ground running. Our first stop was the PCYC, where conversations about youth justice and entrepreneurial skills sparked ideas for young people to be involved in building beds. The Sergeant's enthusiasm opened doors to possibilities we hadn’t anticipated.</p><p id=\"\">At the Rangers' station, we reunited with Richard Cassidy, whose work connects the wisdom of traditional practices with modern tools. The MinggaMingga Land and Sea rangers look after land and sea country surrounding the Palm group of islands, including Great Palm and Orpheus islands, within the Great Barrier Reef World Heritage Area. Their work includes surveying and managing cultural heritage sites, sharing traditional knowledge through on-country activities, monitoring seagrass, coral reefs, and fish species in partnership with researchers, participating in fire management for habitat protection, and managing feral animals and weeds across the islands. Engaging with Elders and key partners, the rangers facilitate progress on caring for country priorities. Nic and I have known Richard for years—myself through Corrective Services and Nic through Orange Sky. Together, we talked about the importance of drone mapping for regeneration projects, using controlled burns and water management. The Rangers' work highlights how different knowledge systems can collaborate, each amplifying the other.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/05c54742-b3a1-4186-b89b-e853877558b5/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Nic and Richard</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/eb9bf84f-085c-4e11-977d-aa3606ddd8a6/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">The young rangers trying out a Greate Bed</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/31b62b69-0ff8-44eb-9cd9-5039d1e7ec34/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Some drone training on day 2 with the young rangers</em></strong></figcaption></figure><p id=\"\">Each bed we built told its own story. Jason, our first recipient, helped with the assembly in his driveway, fascinated by the simplicity. Nic caught up with him as he was getting on the barge, and Jason was beyond excited about his last night's sleep, eager for others to experience the same comfort. Tamika was a glowing advocate, grabbing her neighbours to emphasise how they should try out the bed, proudly showing it off in her house. </p><p id=\"\">Back in the middle of town, the son of a lady who had run the local store for many years gave us a tour, talking us through the challenges of buying a mattress and bed frame on the island. The available options were both very expensive and of poor quality, and shipping from the mainland added even more cost. We looked at the prices in the store and were shocked to see a $469 price tag for a double frame and $479 for the mattress. We learned about the realities of isolation—with frequent breakages of white goods, and the logistical challenges of returns to the mainland.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/38a0ba7f-a422-479d-972e-11181dc485e4/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Making a bed with Jason</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/b764ccb9-22de-4374-908b-66b3ab51e540/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Jason give the thumbs up of approval for his new bed</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/c12cf0e8-6d55-44ff-90c0-2ee5f3b8139e/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Tamika and her new bed freshly made</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1064px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1064px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/aba89e19-755a-4523-b1c9-a9b71967eefc/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">The local store bed ticket prices</em></strong></figcaption></figure><p id=\"\">On the morning of Day 2, the Welcome to Country ceremony at the Story Tree grounded our work in something deeper. Young rangers tended the fire while Uncle Alan Palm Island shared language and story. It was a profound experience for us, with Richard and Uncle Alan helping us feel genuinely welcomed. The young rangers, some participating in the process for the first time, carried out their roles under the watchful eyes of Uncle Alan and Richard. It was incredible to witness and be part of the process of protocol, knowing that each step we took together strengthened our ties and built stronger relationships. The smoke ceremony wasn’t just ritual—it was process, a reminder that meaningful partnership begins with respect for protocol and place. </p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1333px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1333px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/4be71bfd-03e9-4ea9-a454-3dc917897de7/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Welcome ceremony with the Rangers and Uncle Alan Palm Island</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1333px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1333px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/7dcc53f9-7168-48b6-ad40-66d1106221a6/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Alan Palm Island</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/a7fc3e97-ea5b-414d-ab67-e250c410564a/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">The full team in front of the story tree</em></strong></figcaption></figure><p id=\"\">Afterward, Uncle Alan took us to the hospital to show us his painting on the wall, representing stories from his Elders about the island, canoes, and knowledge passed down for thousands of years. He then guided us to the council boardroom, where a traditional canoe was proudly displayed. This was the very canoe that his Elders had used to traverse to the mainland for trade and relations over thousands of years, a tangible symbol of connection, resilience, and the long history of cultural exchange.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/012a6bc6-46b8-442e-8cdb-00c995e06ac7/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Uncle Alan Palm Island and his paintings on the wall of the hospital</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/526c9d6c-7a56-49b0-b020-46be529df1d4/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">The full painting and incredible story</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/a961a842-8aec-49c0-883d-ff2b90ace736/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">A&nbsp;traditional canoe sitting in the council meeting room</em></strong></figcaption></figure><p id=\"\">Our days filled with practical work and testing. Each night, Nic and I alternated between a traditional bed and our own creation at Club Kuta, assessing sleep quality and noting adjustments to improve comfort. We focused on refining our designs, adjusting mattress firmness, and ensuring ease of assembly. Every evening was an opportunity to reflect on the day's progress, tweaking our prototypes to better suit the needs of the community. These small changes were crucial to developing something that was not only practical but also comfortable and durable.</p><p id=\"\">One&nbsp;Day 3, I had the chance to experience ranger Whatta’s mangrove education session with the schoolchildren. It showed how deeply environmental knowledge resonates when it’s shared in context and culture. The young rangers, who had themselves learned from Elders, were now passing that knowledge on to the children—teaching them about the significance of mangroves, the delicate balance of their ecosystems, and the role they play in coastal health. It was inspiring to witness this cycle of knowledge, with the young rangers stepping confidently into teaching roles while the children absorbed every word, their curiosity piqued by hands-on learning. The sense of continuity, of knowledge being passed through generations, reinforced the importance of our work and the relationships we were nurturing.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/36ec1d28-6f90-479f-b83e-96ebd11ac8b3/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Park Ranger Whatta with the class talking mangroves</em></strong></figcaption></figure><p id=\"\">A conversation with Eva Haines, Deputy Chief Executive Officer at Palm Island Aboriginal Shire Council, extended earlier discussions we'd had about the Christmas Cup football carnival. Just a few days earlier, others had suggested we propose the bed initiative to the council. This conversation opened up the idea of using the beds at the upcoming Christmas Cup football carnival—a real-world test and a chance for young people to earn money through bed assembly. Practical opportunities like these can often plant the seeds of sustainable change.</p><p id=\"\">As my plane lifted off on day four, the markers of progress were clear: ten beds crafted and distributed, each providing valuable feedback; a partnership with the Rangers that stretches beyond furniture to include drone mapping for cultural site documentation; and an ambitious plan with the PCYC to engage young people in social enterprise. The Christmas Cup looms as our next milestone—100 beds to be assembled in early December, a testament to the community’s trust and vision. Ongoing connections with Elders like Alan Palm Island remind us that true progress moves at the speed of ceremony, not commerce.</p><p id=\"\">We know we’ll make mistakes, that our feet will stumble on paths we’re still learning to walk. But in each bed built, each conversation shared, each ceremony attended, we’re learning to be better allies, better listeners, better partners in a journey that’s been too long one-sided. In the end, it’s not about the beds—it’s about creating space for local knowledge to flourish, for cultural intelligence to lead, for communities to write their own stories of regeneration and growth.</p><p id=\"\">This truth echoes across our work in Kalgoorlie, the Lower Gulf, Alice Springs and Tennet Creek. It’s present in every prototype we test, every community meeting we attend, every protocol we follow. As the mainland approached, I thought of all we’d left behind—beds that would cradle dreams, conversations that would spark change, connections that would grow like mangrove roots, strong and vital. In my notebook, I wrote not of metrics or timelines, but of privilege and responsibility, of the honour of being invited into stories far older than our own, and of the hope that, in our small way, we’re helping write new chapters that honour the old.</p><p id=\"\">Because true revolution isn’t delivered on a barge or measured in bed frames. It grows in the spaces between ceremony and practical action, between ancient wisdom and modern needs, between listening and doing. It’s found in the moment a young ranger shares knowledge with children, in the pride of a community member assembling furniture, in the simple act of following protocol before any work begins.</p><p id=\"\">This is the path forward—one that bridges the practical with the profound, that measures success not just in units delivered but in relationships strengthened. Each flat-pack bed is an opportunity for connection, each assembly a chance for empowerment, each visit a step in a journey of mutual respect and understanding.</p><p id=\"\">One bed, one connection, one story at a time.</p><p id=\"\"><em id=\"\">BK</em></p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/875c0e44-9b24-4f8a-a5a0-81f29d1f2101/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">A Butler Bay sunrise on Day 3</em></strong></figcaption></figure>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": "act-main",
-      "relatedProjects": [
-        "act-main"
-      ],
-      "relatedProjectSlugs": [
-        "goods-on-country"
-      ],
-      "publishedAt": "2026-01-09T23:40:59.476+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": "https://empathyledger.com/api/media/8c9860bb-4a0b-4706-8516-a6903dc81968/file",
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 18,
-        "videoCount": 0,
-        "photoPreviews": [
-          {
-            "url": "https://empathyledger.com/api/media/8c9860bb-4a0b-4706-8516-a6903dc81968/file",
-            "title": null,
-            "alt_text": null
-          },
-          {
-            "url": "https://empathyledger.com/api/media/01b87716-ffbf-43e6-a2cc-e78150f1bee1/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/8ea5d93b-e148-4945-a154-a4d4573e940f/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/05c54742-b3a1-4186-b89b-e853877558b5/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/eb9bf84f-085c-4e11-977d-aa3606ddd8a6/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/31b62b69-0ff8-44eb-9cd9-5039d1e7ec34/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/38a0ba7f-a422-479d-972e-11181dc485e4/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/b764ccb9-22de-4374-908b-66b3ab51e540/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          }
-        ],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/at-the-speed-of-ceremony-learning-partnership-on-palm-island",
-      "localPath": "/stories/at-the-speed-of-ceremony-learning-partnership-on-palm-island",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "10e81107-559b-4179-a54a-dd72039f71d4",
-      "title": "The Raucous Revolution",
-      "slug": "the-raucous-revolution",
-      "subtitle": null,
-      "excerpt": "From the moment A Curious Tractor sowed its first seeds, we've been dedicated to cultivating a culture of curiosity, creativity, and authenticity. Now, we're excited to introduce a new value to our fertile field - Raucousness.",
-      "content": "<p id=\"\">From the moment A Curious Tractor sowed its first seeds, we've been dedicated to cultivating a culture of curiosity, creativity, and authenticity. Now, we're excited to introduce a new value to our fertile field - Raucousness.</p><p id=\"\">It's a word that tends to get a bad rap.</p><blockquote id=\"\">But what if I told you that a little bit of raucousness could be a good thing?</blockquote><p id=\"\">Let's start from the beginning. The word 'raucous' has a rich history. Derived from the Latin word \"raucus\", it originally meant \"hoarse\". Over time, it came to represent anything loud, rowdy, or disorderly. But I propose a new interpretation of the word. One that goes beyond the negative connotations and celebrates the spirit of enthusiasm, exuberance, and infectious energy.</p><p id=\"\">Picture this. A team meeting where ideas are being thrown around like confetti, voices competing to be heard, laughter filling the room. A raucous meeting, yes, but one filled with creativity, passion, and unbridled energy. A raucousness that encourages us to step out of our comfort zones, to speak up, to engage, to challenge, and to be challenged.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1456px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1456px\"><div><img src=\"https://empathyledger.com/api/media/d7dd9c4f-bbdd-483f-9fc6-1848ec454c82/file\" loading=\"lazy\"></div><figcaption>Something we cooked up earlier</figcaption></figure><p id=\"\">Incorporating raucousness into our values at A Curious Tractor doesn't mean we're advocating for chaos or disorder. It is really the opposite. We want to foster an environment where this energised, lively spirit is harnessed and directed towards productive, creative ends. To this end, we are advocating for a kind of structured raucousness – a raucousness that has a box, that knows its limits.</p><blockquote id=\"\">But how do we strike that balance? How do we ensure that our raucous spirit doesn't spill over into disorder?</blockquote><p id=\"\">Testing our assumptions is key. We will start small, introducing elements of raucousness into brainstorming sessions, and external activities. We will then gather feedback, adjust, and improve. Does our raucous spirit encourage participation or stifle it? Does it foster creativity or create chaos? By closely monitoring these dynamics, we can calibrate the level of raucousness to suit our needs.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/e723c54f-cc2b-4bb1-ac13-f8c5d5b9062c/file\" loading=\"lazy\"></div><figcaption>Nico just getting it done</figcaption></figure><p id=\"\">There's a certain beauty in raucousness. It's the beauty of human emotion, of passion, of the desire to be heard. It's the beauty of engagement, of not just participating but being deeply involved. It's the beauty of a vibrant, thriving community.</p><p id=\"\">As we embark on this raucous revolution, I invite you all to join us. Bring your ideas, your passion, your voice. Help us make A Curious Tractor an energetic community that thrives on the shared passion of its community.</p><p id=\"\">Because everyone needs a little bit of raucousness in their lives. And at A Curious Tractor, we're ready to cultivate it.</p>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": "act-main",
-      "relatedProjects": [
-        "act-main"
-      ],
-      "relatedProjectSlugs": [],
-      "publishedAt": "2026-01-09T23:40:59.476+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": "https://empathyledger.com/api/media/d7dd9c4f-bbdd-483f-9fc6-1848ec454c82/file",
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 2,
-        "videoCount": 0,
-        "photoPreviews": [
-          {
-            "url": "https://empathyledger.com/api/media/d7dd9c4f-bbdd-483f-9fc6-1848ec454c82/file",
-            "title": null,
-            "alt_text": null
-          },
-          {
-            "url": "https://empathyledger.com/api/media/e723c54f-cc2b-4bb1-ac13-f8c5d5b9062c/file",
-            "title": null,
-            "alt_text": null
-          }
-        ],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/the-raucous-revolution",
-      "localPath": "/stories/the-raucous-revolution",
-      "syndicationDestinations": [
-        "act_el"
       ]
     },
     {
@@ -874,7 +478,7 @@
         "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
         "slug": "benjamin-knight",
         "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
+        "avatarUrl": null,
         "bio": null
       },
       "media": {
@@ -916,274 +520,8 @@
       },
       "ctas": [],
       "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/life-is-hard-but-its-not",
+      "canonicalUrl": "https://empathyledger.com/articles/life-is-hard-but-its-not",
       "localPath": "/stories/life-is-hard-but-its-not",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "3b2246d6-9fed-4683-9227-a58b7b648a78",
-      "title": "Between Waters and Worlds: A Day on Quandamooka Country",
-      "slug": "between-waters-and-worlds-a-day-on-quandamooka-country",
-      "subtitle": null,
-      "excerpt": "‍A reflection on connection, knowledge-sharing, and the weaving of futures on Stradbroke Island",
-      "content": "<p id=\"\">The morning light breaks across Moreton Bay as I board the Stradbroke Flyer at 6:30am. This journey to Quandamooka Country has become a pilgrimage of sorts—each visit deepening my understanding of a place where knowledge, strength, and discovery flow like the tides around the island.</p><p id=\"\">Today feels different. I'm joined by companions whose presence creates a small constellation of purpose: Chris Baker, the Food Connect Shed Coordinator, seeking partnerships and oyster wisdom; and Leia Alex, ready to explore storytelling opportunities with local partners. Two fellow travelers open to experiencing all this Country has to offer.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/2c9a476c-8ac4-40d7-98ee-4617304d09c8/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">The Caretaker</h2><p id=\"\">Shaun Fisher welcomes us with the easy warmth of someone deeply connected to this place. His brief departure to take his twins to school—a reminder that he moves between roles as visionary, entrepreneur, and father to six children with practiced grace. While he's gone, we walk through the cemetery, and I feel the accumulating weight of connection to this place, nurtured through conversations with Elders, community members, and young people who have generously shared their time and wisdom.</p><p id=\"\">Upon his return, Shaun takes us to a clearing near his oyster lease—sacred ground for his dreams. In this space, he envisions community gathering places, boat sheds, training facilities, and healing spaces. It's not just infrastructure he describes, but a living ecosystem where economic prosperity intertwines with wellbeing and connection to Country.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/05e21ca8-78d8-4e31-bf72-29b1097d881d/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">History's Shadows</h2><p id=\"\">The drive to the protest camp offers a window into deeper complexities. Shaun speaks of Elders directing the creation of skeleton effigies—powerful symbols of ancestors standing in protection of sacred sites threatened by a proposed whale research centre. His words paint the layered reality of Quandamooka Country: centuries of disruption through disease that decimated 70% of the population, sand mining that claimed over half the island and destroyed dozens of sacred sites, and the ongoing pressure of privileged encroachment.</p><p id=\"\">Our conversation in the car navigates the intricate channels of colonisation's impacts, ecosystem destruction, and the complex relationships between community members with different visions for their Country's future.</p><h2 id=\"\">Waters of Continuity</h2><p id=\"\">Before heading to our meeting at with other partners, we pause at a natural stream—a place Shaun has visited for decades and now shares with his children. This water represents continuity and sustenance, a gathering place where generations have cooled themselves and harvested food from clean waters that still flow despite everything.</p><h2 id=\"\">Convergence on Salt Water</h2><p id=\"\">The day takes an unexpected turn when we learn that Sally and Wapit from Country Connect are at the other ferry terminal. Shaun's boat skims across the water to collect them, creating a powerful convergence: Shaun, the local visionary; Chris, the social enterprise facilitator; Leia, the connection-maker; Sally and Wapit, knowledge carriers from another Country; and myself—still finding my place in this circle, perhaps as witness and reflector of the longer story unfolding through daily efforts.</p><p id=\"\">At the oyster farm, Shaun works with patient explanation, sharing both technique and vision. The farm represents more than livelihood—it's a platform for cultural continuity, family support, and community prosperity. When Wapit speaks of taking these learnings back to his own community, I witness the ancient practice of knowledge exchange being renewed between First Nations peoples.</p><p id=\"\">As we taste oysters together, the moment transcends a simple gathering. It becomes a ceremony of sharing wisdom, building connection, and continuing a story tens of thousands of years in the making.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/ec19edf7-bc2f-4b43-80e3-691a22d02a5d/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/3e15870f-9d1d-49f4-b8af-c3621d1b7bf2/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">Walking Together</h2><p id=\"\">When it's time to leave, Shaun supports Wapit as they walk back to the boat. I capture this image—two knowledge holders walking together—and it resonates deeply within me. In this simple gesture of care and respect, I glimpse the essence of what this work is about.</p><p id=\"\">I still question my role in all of this. Will my storytelling, pre-dawn work sessions, constant travel, and efforts to create moments of visibility make any difference? Can I help ensure Shaun accesses the resources he needs? I don't know.</p><p id=\"\">But I do know I want to keep witnessing moments like these—where small connections reveal profound possibilities. Perhaps the metrics of growth and resource accumulation matter less than showing up faithfully, ready to learn how to support young people and communities in seeing themselves in leaders who walk the full journey with them.</p><p id=\"\">In a system ruled by power dynamics—from billions spent on \"community safety\" to media narratives that profit from fear—I'm here to understand, to build capacity, and to go where this ancient songline guides me. I'm here to keep leaning into uncertainty, to keep turning up without guarantees. Because sometimes, walking alongside others in their journey is enough to begin with.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/dafca401-3d38-4048-be14-f7c426b12a6d/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">‍</p>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": "act-main",
-      "relatedProjects": [
-        "act-main"
-      ],
-      "relatedProjectSlugs": [],
-      "publishedAt": "2026-01-09T23:40:59.476+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": "https://empathyledger.com/api/media/2c9a476c-8ac4-40d7-98ee-4617304d09c8/file",
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 5,
-        "videoCount": 0,
-        "photoPreviews": [
-          {
-            "url": "https://empathyledger.com/api/media/2c9a476c-8ac4-40d7-98ee-4617304d09c8/file",
-            "title": null,
-            "alt_text": null
-          },
-          {
-            "url": "https://empathyledger.com/api/media/05e21ca8-78d8-4e31-bf72-29b1097d881d/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/ec19edf7-bc2f-4b43-80e3-691a22d02a5d/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/3e15870f-9d1d-49f4-b8af-c3621d1b7bf2/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/dafca401-3d38-4048-be14-f7c426b12a6d/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          }
-        ],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/between-waters-and-worlds-a-day-on-quandamooka-country",
-      "localPath": "/stories/between-waters-and-worlds-a-day-on-quandamooka-country",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "8ed1e7cf-63a3-46a6-b728-e33d56f304e0",
-      "title": "The Kids Are Not Alright: How Queensland Is Failing Its Most Vulnerable Young People - And What We Can Do About It",
-      "slug": "the-kids-are-not-alright-how-queensland-is-failing-its-most-vulnerable-young-people-and-what-we-can-do-about-it",
-      "subtitle": null,
-      "excerpt": "In Queensland, our youth justice system is failing our most vulnerable young people, with a billion-dollar plan that prioritizes punishment over addressing the root causes of offending. It's time for a fundamental rethink - one that empowers Aboriginal communities, invests in prevention and healing, and sees the inherent potential in every justice-involved youth as a change-maker and leader in their own life and community.",
-      "content": "<p id=\"\">I can barely remember what it was like to be a kid - but I can be sure that when authority told me to get in line, threatened my character and forced me into the corner - I would bite. I would show them how rebellious I really was. And that's exactly what I see happening with the Queensland government's current approach to youth justice.</p><p id=\"\">The Community Safety Plan, with its billion-dollar budget and focus on increased policing and detention, seems more concerned with appeasing voters in the lead-up to the arbitrary showboating like the Olympics than truly investing in the long-term wellbeing of our state's most vulnerable youth. It's a short-sighted, reactionary approach that fails to address the root causes of offending and instead perpetuates a cycle of harm and disadvantage.</p><p id=\"\">The statistics paint a grim picture. Aboriginal and Torres Strait Islander young people are 24 times more likely to be in detention than their non-Indigenous counterparts, despite making up only 6% of the 10-17 year old population (AIHW, 2021). A staggering 94% of youth in detention have experienced at least one form of neglect, trauma, or abuse (AIFS, 2020). And once caught in the cycle of incarceration, 44% will return within 12 months of release (AIHW, 2020).</p><p id=\"\">It's clear that the current system is failing our young people, and simply doubling down on punishment and deprivation only perpetuates harm. But what if there was another way? What if we looked to the innovative thinking of successful companies to reshape our approach?</p><h1 id=\"\"><strong id=\"\">Act 1: The Reality on the Ground</strong></h1><p id=\"\">To understand what a reimagined youth justice system could look like, we first need to grapple with the realities facing Aboriginal young people in Queensland today. Recent research by Butcher et al. (2021) offers valuable insights from community members across regional and remote areas, where over 40% of Aboriginal youth in the justice system originate.</p><p id=\"\">Through in-depth interviews, a clear picture emerges of the complex web of factors driving youth offending. Poverty and unemployment are rife, with many young people struggling to meet basic needs. Intergenerational trauma from policies of forced removal and cultural dispossession continues to ripple through families and communities. Disconnection from education, country and cultural identity leaves many youth adrift.</p><p id=\"\">As one community member shared: \"If you don't know who you are, you don't know your identity, your sense of self, you don't see a long-term plan because why would you have aspirations in a job where no one can get to towns and the majority of people you know have been in overcrowded houses or struggling to overcome homelessness. It's not a big secret why our numbers are the way they are.\"</p><p id=\"\">Crucially, the research also highlights the incredible strengths and resilience of Aboriginal communities – the strong kinship networks, the deep cultural knowledge, the determination to break cycles of disadvantage. But these community assets are too often overlooked or undermined by top-down, one-size-fits-all interventions.</p><p id=\"\">As another participant advocated, \"You need to start looking at the communities as individuals. So if you can look at a community as an individual, and sort out a case plan for that community, you're going to be fine. But don't force a program from south Sydney, metropolitan area, onto an outreach location, because they are very, very different issues, and they are different communities.\"</p><h1 id=\"\"><strong id=\"\">Act 2: A New Vision</strong></h1><p id=\"\">So what would it look like for the Queensland government to put these community insights at the centre of a transformed youth justice agenda? To start, it would mean a fundamental shift in mindset and power dynamics.</p><p id=\"\">Rather than viewing youth offending through a narrow lens of individual deficits and deviance, policymakers would adopt a systems perspective – mapping out the complex interplay of structural, cultural and situational factors that shape a young person's trajectory. This holistic view would spur investment in the social determinants of youth wellbeing, such as housing, healthcare, education and employment pathways.</p><p id=\"\">It would also prompt a reorientation of resources from back-end detention to front-end prevention and diversion. Imagine if even a fraction of the current youth justice budget was redirected to evidence-based, community-led early intervention programs that provide mentoring, cultural connection, and wrap-around support to at-risk youth and families. The long-term social and economic returns would far outweigh the short-term political appeal of seeming 'tough on crime'.</p><p id=\"\">Critically, this new vision would position Aboriginal communities as essential partners in co-designing and co-delivering youth justice solutions. Policymakers would take their lead from Aboriginal Elders, organisations and young leaders, respecting their cultural authority and deep understanding of local needs and strengths. Initiatives like community-based healing circles, bush camps, and cultural mentoring would be elevated and scaled, leveraging Aboriginal ways of being and doing.</p><p id=\"\">Accountability would be reframed around what communities value, with success measured not just by recidivism rates but by indicators of social and emotional wellbeing, cultural identity, and community empowerment. Youth and families would be active participants in shaping programs and tracking outcomes - their voices and aspirations at the forefront.</p><h1 id=\"\">Act 3: A Call to Action</h1><p id=\"\">Achieving this vision will require courageous leadership and a willingness to challenge entrenched attitudes and practices. It means ceding power and control to those with lived experience and cultural wisdom. It means investing for the long-haul and embracing the uncertainty of innovation.</p><p id=\"\">But the alternative - more of the same revolving door of youth detention and despair - is unacceptable. As a society, we have a moral imperative to do better by our most vulnerable young people. And in truth, a youth justice system that heals and empowers rather than punishes and marginalises benefits us all.</p><p id=\"\">So to our policymakers, we say: be brave. Look beyond the next news cycle or election to the kind of Queensland we want to create for generations to come. Partner with Aboriginal communities to forge a new path guided by their knowledge and resilience. Invest in the potential of our youth, not the expansion of our prisons.</p><p id=\"\">And to our fellow Queenslanders: lend your voice to the call for change. Challenge the narratives of fear and retribution that drive failed policies. Champion community-led solutions and hold our leaders accountable for delivering real results.</p><p id=\"\">Together, we can transform youth justice from a site of trauma and stigma to a source of healing, hope and restoration. We can build a Queensland where every young person has the opportunity and support to thrive. Let us seize this moment, learn from past failings, and take inspiration from innovative frameworks to forge a more just, compassionate and effective way forward.Our kids are counting on us.</p><p id=\"\">‍</p>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": "act-main",
-      "relatedProjects": [
-        "act-main"
-      ],
-      "relatedProjectSlugs": [
-        "justicehub"
-      ],
-      "publishedAt": "2026-01-09T23:40:59.476+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": null,
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 0,
-        "videoCount": 0,
-        "photoPreviews": [],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/the-kids-are-not-alright-how-queensland-is-failing-its-most-vulnerable-young-people-and-what-we-can-do-about-it",
-      "localPath": "/stories/the-kids-are-not-alright-how-queensland-is-failing-its-most-vulnerable-young-people-and-what-we-can-do-about-it",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "75101fd0-9501-4edb-a511-6fb3fbcef8e9",
-      "title": "Dear Souls Adrift in this Vast Expanse",
-      "slug": "its-overwhelming-isnt-it",
-      "subtitle": null,
-      "excerpt": "It's overwhelming, isn't it?",
-      "content": "<h2 data-sp-article=\"PP4KPPDEZ.10\" id=\"23c33df3-e44a-4ebc-85d4-6b2f0d87a11a\">Dear Souls Adrift in this Vast Expanse</h2><p>In a world that oscillates between the cacophony of dissent and the silence of compliance, there lies a narrow path. It's a path that demands the courage to speak, yet the wisdom to listen; the fortitude to act, yet the compassion to empathise. As I pen down these words, the world outside is a theatre of contradictions. Votes are being cast—simple 'yes' or 'no' checkboxes that somehow are expected to encapsulate our complex moral landscapes. Wars rage on in distant lands, their reverberations unsettling the very ground we stand upon. And here, in our microcosms, the chasm between abundance and need widens, almost as if mocking our shared humanity.</p><p>It's overwhelming, isn't it? The weight of the world's woes can stifle our voices, drown them in the sea of collective noise. We're often led astray by the cacophonous opinions of those around us, diminishing the potency of our individual voices, urging us to follow the crowd into an abyss of moral compromise.</p><p>Yet, here's the paradox: sometimes our voice, when finally unleashed, can be a double-edged sword. It can sever the ties that bind us to family, friends, and community. It can invite a torrent of vitriol, both online and in the flesh, making us question the very act of speaking out. It's a precarious balance, one that leaves us teetering on the edge of action and inaction, speech and silence.</p><p>Doing nothing is often not an option; the world's stage is not one that tolerates passive spectators. But choosing where to lend your voice, where to invest your emotional and moral capital—that is the crux. It's a choice that requires not just bravery but also empathy, the ability to step into another's shoes and see the world through a lens tinted with compassion and understanding.</p><div data-type=\"regular\" data-title=\"<p>Photo by <a href=&quot;https://unsplash.com/@fakurian?utm_source=Storipress&utm_medium=referral&utm_campaign=api-credit?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit&quot;>Milad Fakurian</a> / <a href=&quot;https://unsplash.com/?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit&quot;>Unsplash</a></p>\" data-source=\"[]\" data-link=\"\" data-style=\"\" data-alt=\"n the world we live in, every small decision can set off a chain reaction, much like dominos, influencing the significant events in our lives. Drawing inspiration from the domino effect and some of my old works that have captivated millions of viewers until today, I have redesigned this collection. I am thrilled to share it with you. If you enjoy it, feel free to tag me in your Instagram stories and share your feelings about this collection with others\" data-src=\"https://empathyledger.com/api/media/11350935-82c9-4789-9bc6-a0cf15e82605/file\" data-format=\"image\" class=\"clear-both mx-auto\"><figure><picture><img type=\"regular\" link=\"\" title=\"<p>Photo by <a href=&quot;https://unsplash.com/@fakurian?utm_source=Storipress&utm_medium=referral&utm_campaign=api-credit?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit&quot;>Milad Fakurian</a> / <a href=&quot;https://unsplash.com/?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit&quot;>Unsplash</a></p>\" alt=\"n the world we live in, every small decision can set off a chain reaction, much like dominos, influencing the significant events in our lives. Drawing inspiration from the domino effect and some of my old works that have captivated millions of viewers until today, I have redesigned this collection. I am thrilled to share it with you. If you enjoy it, feel free to tag me in your Instagram stories and share your feelings about this collection with others\" source=\"\" src=\"https://empathyledger.com/api/media/11350935-82c9-4789-9bc6-a0cf15e82605/file\"></picture><figcaption class=\"pt-2 block caption-text\"><div><p>Photo by <a href=\"https://unsplash.com/@fakurian?utm_source=Storipress&utm_medium=referral&utm_campaign=api-credit?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit\">Milad Fakurian</a> / <a href=\"https://unsplash.com/?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit\">Unsplash</a></p></div></figcaption></figure></div><p>I am no oracle, no sage with answers to the world's complex questions. I am but a humble wanderer, searching for my place in this intricate web of existence. Yet, I yearn for the courage to say what I believe, to stand against the tides of popular opinion when my soul urges me to do so. And if I err, let me have the humility to admit it, for the path to wisdom is paved with the bricks of our mistakes.</p><p>So, as the world turns and decisions loom large, I cast my vote for 'Yes.' I cannot, in good conscience, support the wars tearing apart the fabric of communities in Israel and Ukraine. I beseech those in positions of power to recognize their role in sculpting a more equitable world. And above all, I hope that our dialogues can transcend the pettiness of name-calling, the futility of violence, and be imbued with the essence of empathy and understanding.</p><p>For in the end, it is not just bravery that we need, but a bravery laced with empathy—a courage that listens as much as it speaks, that acts not just with resolve but also with compassion.</p><p>With a heart full of hope and a soul yearning for peace,</p><p data-sp-article-end=\"PP4KPPDEZ.10\">A Fellow Traveler</p>\n<script async type=\"module\" src=\"https://script-providers.storipress.workers.dev/storipress.mjs?client=PP4KPPDEZ&platform=webflow\"></script>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": "act-main",
-      "relatedProjects": [
-        "act-main"
-      ],
-      "relatedProjectSlugs": [],
-      "publishedAt": "2026-01-09T23:40:59.476+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": null,
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 0,
-        "videoCount": 0,
-        "photoPreviews": [],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/its-overwhelming-isnt-it",
-      "localPath": "/stories/its-overwhelming-isnt-it",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "30f9717c-77bc-4e55-8756-c5cd1e310c2b",
-      "title": "The Weight of Silence and the Audacity to Imagine: Reflections on Fear, Hope, and the Long Game of Human Liberation",
-      "slug": "the-weight-of-silence-and-the-audacity-to-imagine-reflections-on-fear-hope-and-the-long-game-of-human-liberation",
-      "subtitle": null,
-      "excerpt": "This is Part 1 of an ongoing series exploring the intersection of personal transformation and systemic change. A Curious Tractor exists to create spaces for this kind of collective reimagining—working with organisations and communities ready to move beyond fixing broken systems toward building entirely new ones. Join the conversation by sharing your own reflections on how we might build communities organised around healing rather than harm. Drop a comment, share your story, challenge my thinking let's explore what becomes possible when we dare to imagine differently.",
-      "content": "<p id=\"\">‍<em id=\"\">In this moment of profound transition, we stand at the intersection of possibility and potential and I've been struggling with the weight of what I see unfolding around us.</em></p><p id=\"\">I've been quiet lately. Not absent, but quiet in the way that deep waters run silent, processing, witnessing, feeling the collective pull toward conversations that diminish rather than expand our humanity. Every government press release celebrating another youth arrest, every politician performing \"tough on crime\" theatre, every comment thread dissolving into tribal warfare over who deserves safety and who deserves punishment feels like watching a society choose the smallest version of itself.</p><p id=\"\"><em id=\"\">And I've been asking myself: How do we speak truth into a world that seems increasingly committed to its own mythology of scarcity and separation?</em></p><h2 id=\"\">The Personal Ecology of Systemic Transformation</h2><p id=\"\">My journey into this work didn't begin with policy papers or budget analyses. It began, as most authentic transformations do, in the messy intersection of personal experience and collective awakening. Years of youth work taught me that the young people society labels as \"problems\" are often our greatest teachers - mirrors reflecting back the systems that have failed them, the communities that have abandoned them, the adults who have forgotten what it means to see potential in the face of pain.</p><p id=\"\"><em id=\"\">Our mountains are both institutional and internal - requiring courage, vulnerability, and an unwavering commitment to seeing beyond current limitations.</em></p><p id=\"\">This understanding eventually led me to create A Curious Tractor. Not because the world needed another consulting business, but because I kept encountering organisations, communities, and leaders who were asking the same fundamental question: <em id=\"\">How do we build something different when we're trapped inside systems designed for a world that no longer serves us?</em></p><p id=\"\">A Curious Tractor emerged from a simple recognition: that most of our approaches to change - whether in youth justice, organisational development, or community transformation - are still rooted in the same mechanistic thinking that created the problems we're trying to solve. We're trying to fix broken systems using the same logic that broke them in the first place.</p><p id=\"\"><em id=\"\">What if the path forward requires not just different strategies, but entirely different ways of thinking about change itself?</em></p><p id=\"\">The work we do through A Curious Tractor is about creating spaces for collaborative learning and development that honour the complexity of human systems. It's about working with organisations and communities to build capacity for transformation from the inside out. It's about recognising that sustainable change isn't something we do <em id=\"\">to</em> systems, it's something that emerges <em id=\"\">from</em> systems when we create the conditions for collective reimagining.</p><p id=\"\"><em id=\"\">We are not just participants, but architects of a new paradigm. Each conversation, each connection becomes a thread in a larger tapestry of collective reimagining.</em></p><p id=\"\">Every engagement, whether with a community organisation struggling to serve complex needs or a corporation trying to navigate rapid change, becomes an opportunity to practice what we preach: that transformation happens through relationship, that wisdom emerges from collective inquiry, that the solutions we need already exist within the communities experiencing the challenges.</p><h2 id=\"\">The Weight of Contradiction</h2><p id=\"\">But here's what keeps me awake at night: while we're working with organisations to embrace collaborative learning, vulnerability, and systemic thinking, the broader society seems to be moving in the opposite direction. While we're helping leaders understand that complex challenges require collective wisdom, our political systems are celebrating simplistic solutions to multifaceted problems.</p><p id=\"\"><em id=\"\">How do you maintain hope while watching a state spend $859,589 annually to warehouse each child in detention, knowing that the same money could transform thousands of young lives through the kind of collaborative, healing-centred approaches we know actually work?</em></p><p id=\"\">The mathematics are staggering in their moral clarity:</p><ul id=\"\"><li id=\"\">$318+ million spent on a youth justice system with a 68% failure rate</li><li id=\"\">22-33 times higher detention rates for Indigenous children</li><li id=\"\">Youth crime representing only 13% of total crime while consuming disproportionate resources</li><li id=\"\">Community programs that work receiving table scraps while detention infrastructure gets hundreds of millions</li></ul><p id=\"\"><em id=\"\">But the numbers, devastating as they are, tell only part of the story.</em></p><p id=\"\">What breaks my heart is witnessing the cognitive dissonance between what we know works in human development and what we continue to fund in public policy. Every day through A Curious Tractor, we see organisations discovering that when you create conditions for authentic collaboration, when you honour the wisdom present in every community, when you design systems around human flourishing rather than control and compliance, remarkable transformations become possible.</p><p id=\"\"><em id=\"\">Yet these same insights which seem obvious in organisational development contexts become radical impossibilities when applied to criminal justice, education, or social services.</em></p><h2 id=\"\">The Conversation We're Not Having</h2><p id=\"\">The public discourse around youth justice has become a carefully choreographed dance of moral posturing that avoids the questions that matter most:</p><p id=\"\"><em id=\"\">What kind of society do we want to be? What do we believe about human nature and the possibility for transformation?What are we actually protecting, and what are we actually destroying? How do we measure success in a system designed to heal rather than harm?</em></p><p id=\"\">Through A Curious Tractor's work, we've seen what happens when organisations are brave enough to engage these deeper questions. We've watched teams discover that their most entrenched conflicts contain the seeds of their greatest breakthroughs. We've facilitated processes where communities in crisis become laboratories for innovation. We've witnessed leaders learn that vulnerability isn't weakness it's the foundation of authentic authority.</p><p id=\"\"><em id=\"\">The most unsafe thing we can do is continue investing in approaches that create more trauma, more disconnection, more cycles of harm.</em></p><p id=\"\">But these lessons, which feel revolutionary in organisational contexts, are exactly what Indigenous communities have been practicing for thousands of years, what restorative justice practitioners have been demonstrating for decades, what countries like Portugal and Norway have been proving at scale for years.</p><p id=\"\"><em id=\"\">The question is not whether transformation is possible. The question is whether we have the courage to choose it.</em></p><h2 id=\"\">The Practice of Collective Transformation</h2><p id=\"\">Every engagement with A Curious Tractor becomes an experiment in applied hope. Spaces where power is shared rather than hoarded. Processes where wisdom emerges from collective inquiry rather than individual expertise. Approaches where healing and productivity aren't in competition but are recognized as interdependent.</p><p id=\"\">When we facilitate strategic planning processes that begin with personal reflection and end with collective commitment, we're practicing the integration of inner and outer transformation. When we design learning experiences that honour both individual growth and systemic change, we're modelling what becomes possible when we stop treating personal development and social justice as separate endeavors.</p><p id=\"\"><em id=\"\">Every breakthrough begins with the audacity to imagine differently.</em></p><p id=\"\">But I'm tired of this work existing only in the margins, only in the spaces where people already believe transformation is possible. I'm frustrated that the insights emerging from collaborative learning processes aren't informing how we design criminal justice systems, education policies, or community response to crisis.</p><p id=\"\">This is why I've been quiet. Not because I've lost hope, but because I've been feeling the full weight of what we're choosing as individuals, as communities, as a society. <em id=\"\">In this moment of profound transition, we stand at the intersection of possibility and potential and we're choosing fear.</em></p><p id=\"\">I see a nation so privileged, so resourced, so capable of profound transformation, and we're being drawn into conversations that divide rather than unite, that diminish rather than expand, that close possibilities rather than open them. We're talking about protecting \"what's ours\" without examining what ownership means in a world where Indigenous children are detained at rates that can only be described as systematically genocidal.</p><p id=\"\"><em id=\"\">What are we actually hoarding when we hoard wealth, safety, opportunity? What are we actually protecting when we build walls instead of bridges? What are we actually achieving when winning arguments becomes more important than healing communities?</em></p><p id=\"\">The young people cycling through our justice system aren't abstractions to be managed or problems to be solved they are our children, carrying trauma we inflicted, responding to abandonment we created, reflecting back the violence we normalized. They are mirrors showing us exactly who we've chosen to become.</p><p id=\"\"><em id=\"\">Our mountains are both institutional and internal requiring courage, vulnerability, and an unwavering commitment to seeing beyond current limitations.</em></p><p id=\"\">The transformation Queensland needs, that Australia needs, that our world desperately needs, cannot be achieved through policy reform alone. It requires what Indigenous communities have always known, what our best organisational development work confirms: that healing the systems requires healing ourselves, that changing the world requires changing our consciousness, that sustainable transformation emerges from the inside out.</p><p id=\"\">This is the heart of A Curious Tractor's approach: recognising that the quality of our external systems reflects the quality of our internal capacity for connection, collaboration, and care. That the way we treat the most vulnerable in our society mirrors the way we treat the most vulnerable parts of ourselves.</p><p id=\"\"><em id=\"\">Money means fuck all if we don't have connections with people around us. Safety means nothing if it's built on other people's suffering. Being right is worthless if it comes at the cost of being human.</em></p><p id=\"\">The path forward requires us to become comfortable with not knowing, with being wrong, with having our assumptions challenged by people whose experiences we've never lived. It requires curiosity over certainty, questions over answers, vulnerability over defensiveness.</p><p id=\"\">What if we stopped trying to fix broken systems and started building new ones? What if we applied the same collaborative learning principles that transform organisations to transforming our approach to community safety? What if we measured success by how many young people we helped flourish rather than how many we managed to contain? What if we organised our communities around the principle that every person carries gifts the world desperately needs?</p><p id=\"\">This is not naive optimism - this is the same radical pragmatism that guides every A Curious Tractor engagement. The recognition that complex challenges require collective wisdom, that sustainable solutions emerge from authentic relationship, that transformation happens when we create conditions for it rather than trying to force it.</p><p id=\"\"><em id=\"\">The evidence is overwhelming that approaches rooted in healing, connection, and restoration create better outcomes for everyone involved.</em></p><p id=\"\">Portugal's health-focused drug policy. Norway's rehabilitation-centred prisons. Finland's collaborative education system. Boston's community policing model. These aren't utopian fantasies - they are practical demonstrations that different choices create different realities. They are large-scale applications of the same principles that make collaborative learning processes so transformative: starting with human dignity, honouring complexity, building from wisdom that already exists within communities.</p><p id=\"\">I'm here to think deeper about this. I'm going to say some real shit that people won't like. I'm here to push boundaries on what we accept as normal, as inevitable, as \"just the way things are.\"</p><p id=\"\">Because if we're not challenged to think differently, if we're not curious about whether we might be wrong, if we're not always questioning our assumptions about human nature and social possibilities, then we're just reproducing the same patterns that got us here.</p><p id=\"\"><em id=\"\">This blog, this work, A Curious Tractor itself, it's all an invitation to anyone ready to move beyond the binary thinking that keeps us trapped in cycles of harm.</em></p><p id=\"\">It's for people willing to examine their own investments in punishment and control. It's for communities ready to experiment with healing-centred responses to conflict. It's for organisations brave enough to design systems around human flourishing rather than fear and compliance. It's for anyone who suspects that the way things are is not the way things have to be.</p><p id=\"\"><em id=\"\">Together, we climb toward something that doesn't exist yet.</em></p><p id=\"\">Not because the path is clear, but because the destination is worthy. Not because we have all the answers, but because we're willing to live in the questions. Not because change is easy, but because the alternative - continuing to fund failure, to warehouse trauma, to systematically destroy the potential of our most vulnerable children is unacceptable.</p><h2 id=\"\">The Audacity of Love</h2><p id=\"\"><em id=\"\">Every breakthrough begins with the audacity to imagine differently.</em></p><p id=\"\">What I'm proposing through this work, through A Curious Tractor, through this writing, is not policy reform. What I'm proposing is a revolution in how we understand human nature, community safety, and our responsibility to each other. What I'm proposing is that we organise our society around the same radical assumptions that make collaborative learning so powerful: that every person carries wisdom, that collective intelligence emerges when we create conditions for it, that transformation is possible when we stop trying to force it and start creating space for it.</p><p id=\"\">This is the audacity of love: the willingness to see beyond current behaviour to human potential, to invest in possibilities rather than just manage problems, to build systems that call forth our highest rather than reinforce our lowest.</p><p id=\"\"><em id=\"\">In this moment of profound transition, we have a choice.</em></p><p id=\"\">We can continue pouring millions into the machinery of punishment while children sleep in police watch houses and Indigenous families are systematically destroyed. We can keep celebrating arrest statistics while ignoring the human cost of our collective failure to imagine better.</p><p id=\"\">Or we can choose the path that Portugal, Norway, and countless communities around the world have already mapped: the path from punishment to transformation, from fear to love, from systems that diminish to systems that dignify. The same path that guides every meaningful organisational transformation, every authentic leadership development process, every collaborative learning experience that actually changes how people see themselves and their possibilities.</p><p id=\"\"><em id=\"\">The choice is ours. The time is now. The future is unwritten.</em></p>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": "act-main",
-      "relatedProjects": [
-        "act-main"
-      ],
-      "relatedProjectSlugs": [],
-      "publishedAt": "2026-01-09T23:40:59.476+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": null,
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 0,
-        "videoCount": 0,
-        "photoPreviews": [],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/the-weight-of-silence-and-the-audacity-to-imagine-reflections-on-fear-hope-and-the-long-game-of-human-liberation",
-      "localPath": "/stories/the-weight-of-silence-and-the-audacity-to-imagine-reflections-on-fear-hope-and-the-long-game-of-human-liberation",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "905415f9-bf80-4bd6-9495-39db2fb0a5ee",
-      "title": "CONTAINED: Where Policy Meets Flesh",
-      "slug": "contained-where-policy-meets-flesh",
-      "subtitle": null,
-      "excerpt": "Share this if you're done watching children being destroyed for profit while we pretend it's justice.",
-      "content": "<h1 id=\"\">This Isn't Another Report to Die in Your Downloads Folder</h1><p id=\"\">This is Isaiah's skeleton remembering surveillance cameras. This is fluorescent light at 120 Hz living between your molars and your amygdala. This is what happens when we stop intellectualising trauma and start feeling it in our bones.</p><p id=\"\"><strong id=\"\">Three rooms. 30 minutes. The entire truth about youth justice.</strong></p><h3 id=\"\">WHY THIS EXISTS</h3><h2 id=\"\">Because I'm Drowning in the Disconnect</h2><p id=\"\">Politicians tweet about youth crime from offices they'll never leave. Million-dollar reports written by people who've never heard institutional despair. Conferences where we intellectualise children trying not to die inside.</p><p id=\"\">Meanwhile, Isaiah walks into Room 1 and his shoulders tell us more truth in three seconds than every policy paper ever written.</p><p id=\"\"><em id=\"\">\"I was just watching your face and you're like, 'What the f</em>**?'\"*</p><p id=\"\">That's not shock. That's recognition. That's a body having a conversation with its past.</p><p id=\"\"><strong id=\"\">We built this container because understanding and KNOWING are different creatures entirely.</strong></p><h3 id=\"\">THE THREE ROOMS</h3><h4 id=\"\">Room 1: Brisbane's Reality</h4><p id=\"\"><em id=\"\">12 minutes of institutional truth</em></p><p id=\"\">Steel bench because <em id=\"\">\"timber could become a weapon.\"</em> Everything bolted down because <em id=\"\">\"hope gets dangerous when it's portable.\"</em> Mesh windows that turn sunlight into something industrial and impossible.</p><p id=\"\">Isaiah stood here and marked these walls. Not vandalism - archaeology in reverse. Proof that young people survive these spaces despite them, not because of them.</p><p id=\"\"><strong id=\"\">This room costs $2,355 per day. Per child. To manufacture trauma.</strong></p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/9d001a37-f487-4731-9674-76e320da8c53/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><h4 id=\"\">Room 2: What We Already Know Works</h4><p id=\"\"><em id=\"\">15 minutes of radical humanity</em></p><p id=\"\">Sunset-coloured walls. Cordless phone. Family photos. Dignity made tangible.</p><p id=\"\">Isaiah's assessment: <em id=\"\">\"Massive difference.\"</em></p><p id=\"\">That's it. That's the whole fucking report. One young man, two rooms, one word. Everything else is just expensive noise.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/b5f66c96-df28-4b5f-bb82-b181315bea2e/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><h4 id=\"\">Room 3: Your Commitment</h4><p id=\"\"><em id=\"\">3 minutes to stop pretending you don't know</em></p><p id=\"\">This is where you stop being a tourist in other people's trauma. Sign something. Fund something. Change something. Or admit you're comfortable with children being destroyed at $859,589 per year.</p><p id=\"\"><strong id=\"\">No exit without commitment. That's the deal.</strong></p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/3d8ee7c9-0c00-4b48-97e6-82a11e77f2ae/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><h3 id=\"\">WHO NEEDS TO WALK THROUGH</h3><h4 id=\"\">Politicians</h4><p id=\"\">Bring your tough-on-crime tweets. Leave with Isaiah's scratches under your fingernails.</p><h4 id=\"\">Policymakers</h4><p id=\"\">Bring your evidence-based frameworks. Leave understanding that evidence has a nervous system.</p><h4 id=\"\">Everyone Who Says \"But What About the Victims?\"</h4><p id=\"\">Isaiah WAS a victim. Then we made him one again, systematically, at taxpayer expense.</p><h4 id=\"\">You</h4><p id=\"\">Because watching this through a screen isn't enough anymore.</p><h3 id=\"\">THE ISAIAH PRINCIPLE</h3><p id=\"\">After years in rooms like Room 1, Isaiah said:</p><p id=\"\"><em id=\"\">\"I would prefer [people didn't] have to experience this to bring change.\"</em></p><p id=\"\">He wishes the people funding torture chambers could understand without feeling even a fraction of what he endured. That's not forgiveness - that's humanity so profound it indicts the system more than any container could.</p><p id=\"\">But his gentleness won't change policy. His wisdom won't shift budgets.</p><p id=\"\"><strong id=\"\">What might work is making you sit where he sat.</strong></p><h3 id=\"\">BUILT BY PEOPLE WHO ARE DONE TALKING</h3><p id=\"\"><strong id=\"\">Benjamin Knight</strong>: The insomniac who follows paper trails to kids in cages<br><strong id=\"\">Nicholas Marchesi</strong>: Built these containers with his hands because revolution needs carpenters<br><strong id=\"\">Isaiah</strong>: Marked the walls so you can't pretend you don't know<br><strong id=\"\">Young Architects</strong>: Who survived the system and now design its replacement</p><p id=\"\">This is our middle finger to every conference that pontificates about \"trauma-informed care\" while children scratch their names into walls just to prove they exist.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/e9191057-d535-4cad-9401-573676cf87bf/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">The Blog Post: \"Isaiah Marked These Walls\"</h2><p id=\"\">I'm done with the conferences. Done with the PowerPoints about \"evidence-based practice\" and \"therapeutic frameworks\" and whatever other language we use to avoid saying: we're torturing children and charging $859,589 per year for the privilege.</p><p id=\"\">I built a shipping container because I needed something real. Three rooms that show the distance between destruction and dignity. Not another report. Not another pilot program. Just steel and fluorescent lights and the truth that lives in Isaiah's bones.</p><h3 id=\"\">When Isaiah Walked In</h3><p id=\"\">His shoulders shifted first - that specific contraction of someone whose spine remembers surveillance like a second skeleton. The fluorescent hit him at 120 Hz, that frequency that lives between your molars and your amygdala, and his eyes started darting: <em id=\"\">\"Dart to dart. The eyes are darting all down.\"</em></p><p id=\"\">Three years out of detention. Doesn't matter. His body remembers everything.</p><p id=\"\">Someone watched his face change and said: <em id=\"\">\"You're like, 'What the f</em>**?'\"*</p><p id=\"\">But Isaiah wasn't surprised. He was home. Not the good kind of home - the kind that's written into your nervous system, the kind you can't forget even when you're free.</p><h3 id=\"\">The Archaeology of Truth</h3><p id=\"\">Isaiah picked up something sharp and started scratching the walls.</p><p id=\"\"><em id=\"\">\"Do it. Get some rocks,\"</em> someone said.</p><p id=\"\">This wasn't vandalism. This was documentation. Every scratch both wound and suture, proof and promise. The sound filled the container - that specific scraping every detention survivor knows, the soundtrack to carving your existence into surfaces designed to forget you.</p><p id=\"\">He knows why the bench is steel: <em id=\"\">\"If it was timber, you could jump on it and make a weapon.\"</em></p><p id=\"\">He knows why everything's bolted: <em id=\"\">\"Hope gets dangerous when it's portable.\"</em></p><p id=\"\">These aren't design choices. They're philosophical statements about which children deserve futures and which deserve warehousing.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/a71035b8-bf41-4150-83bf-40fe122e4dcd/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><h3 id=\"\">Room 2 Changed Everything</h3><p id=\"\">The Spanish model. Sunset walls. Cordless phone (CORDLESS - imagine trusting a teenager). Family photos.</p><p id=\"\">Isaiah's assessment: <em id=\"\">\"Massive.\"</em></p><p id=\"\">One word. That's the entire finding. That's what a million-dollar evaluation would conclude if it had the balls to be honest: treating kids like humans works better than treating them like hazardous waste.</p><p id=\"\">Revolutionary.</p><h3 id=\"\">The Heartbreak</h3><p id=\"\">Here's what destroyed me: After everything, Isaiah looked at this container designed to give politicians just 10 minutes of his years of hell, and said:</p><p id=\"\"><em id=\"\">\"I would prefer [people didn't] have to experience this to bring change.\"</em></p><p id=\"\">This young man who survived systematic dehumanisation wishes his torturers could understand without having to feel what he felt. His humanity is so vast it makes the system look even smaller.</p><h3 id=\"\">Why This Matters</h3><p id=\"\">All those conferences where intelligent people with degrees discuss \"best practice\" while never asking Isaiah what would have actually helped. All those politicians who tweet about youth crime between champagne functions. All those reports that die in downloads folders while kids die in detention.</p><p id=\"\">The container is my response to all of that. It's Isaiah's scratches made manifest. It's the difference between reading about drowning and water filling your lungs.</p><p id=\"\">Isaiah marked these walls. Now politicians will touch them. Feel them. Stand where he stood.</p><p id=\"\">And maybe - just fucking maybe - they'll understand that every scratch is a young person saying:</p><p id=\"\"><em id=\"\">I was here.<br>I survived.<br>Despite you, not because of you.<br>Now listen to what would have actually helped.</em></p><h3 id=\"\">The Call</h3><p id=\"\">We open October 22nd. Sydney.</p><p id=\"\">You'll sit where Isaiah sat. Feel what he felt. For just 10 minutes of his years.</p><p id=\"\">Then you'll walk into Room 2 and understand that we choose this violence. We fund this failure. We could have dignity and cordless phones and futures, but we choose steel benches and mesh windows and children who learn to sleep listening for footsteps.</p><p id=\"\">Room 3 is where you commit to something real. Or don't come.</p><p id=\"\">This isn't about feeling bad. This isn't about guilt. This is about Isaiah working at Interlace Advisory now, helping young people who recognise him immediately - <em id=\"\">\"You've been in trouble\"</em> - because authenticity doesn't need certification.</p><p id=\"\">This is about the fact that we know what works. We've known forever. We just choose not to do it because fear wins elections and healing doesn't photograph well.</p><p id=\"\">The container is waiting. Isaiah's marks are on the walls.</p><p id=\"\">The question isn't whether you'll feel uncomfortable.</p><p id=\"\">The question is whether you'll do anything about it.</p><p id=\"\"><strong id=\"\">[Book your 30 minutes with truth]</strong></p><p id=\"\"><strong id=\"\">[Or keep pretending you don't know]</strong></p><p id=\"\">#CONTAINED #IsaiahsTruth #NoMoreConferences #SystemChange</p><p id=\"\"><em id=\"\">Share this if you're done watching children being destroyed for profit while we pretend it's justice.</em></p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1184px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1184px\"><div><img src=\"https://empathyledger.com/api/media/6440b010-fdbd-4b0c-baab-bf006d96e074/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure>",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": "act-main",
-      "relatedProjects": [
-        "act-main"
-      ],
-      "relatedProjectSlugs": [
-        "justicehub"
-      ],
-      "publishedAt": "2026-01-09T23:40:59.476+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [],
-      "themes": [],
-      "featuredImageUrl": "https://empathyledger.com/api/media/9d001a37-f487-4731-9674-76e320da8c53/file",
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 4,
-        "videoCount": 0,
-        "photoPreviews": [
-          {
-            "url": "https://empathyledger.com/api/media/9d001a37-f487-4731-9674-76e320da8c53/file",
-            "title": null,
-            "alt_text": null
-          },
-          {
-            "url": "https://empathyledger.com/api/media/b5f66c96-df28-4b5f-bb82-b181315bea2e/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/3d8ee7c9-0c00-4b48-97e6-82a11e77f2ae/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/e9191057-d535-4cad-9401-573676cf87bf/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          }
-        ],
-        "videoPreviews": []
-      },
-      "ctas": [],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/contained-where-policy-meets-flesh",
-      "localPath": "/stories/contained-where-policy-meets-flesh",
       "syndicationDestinations": [
         "act_el"
       ]
@@ -1216,7 +554,7 @@
         "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
         "slug": "benjamin-knight",
         "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
+        "avatarUrl": null,
         "bio": null
       },
       "media": {
@@ -1227,19 +565,19 @@
       },
       "ctas": [],
       "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/justicehub-a-platform-for-community-led-justice-solutions",
+      "canonicalUrl": "https://empathyledger.com/articles/justicehub-a-platform-for-community-led-justice-solutions",
       "localPath": "/stories/justicehub-a-platform-for-community-led-justice-solutions",
       "syndicationDestinations": [
         "act_el"
       ]
     },
     {
-      "id": "48cce05b-c7da-45d1-89a8-f5e54ff99ef2",
-      "title": "The Tapestry of Dignity: Witnessing the Birth of the Global Laundry Alliance",
-      "slug": "the-tapestry-of-dignity-witnessing-the-birth-of-the-global-laundry-alliance",
+      "id": "10e81107-559b-4179-a54a-dd72039f71d4",
+      "title": "The Raucous Revolution",
+      "slug": "the-raucous-revolution",
       "subtitle": null,
-      "excerpt": "The Global Laundry Alliance represents a radical reimagining of how social change manifests—not through isolated interventions but through collective wisdom, not through competition but through collaboration, not through prescription but through possibility.",
-      "content": "<p id=\"\">In the gentle April sunshine of Athens, I witnessed something quietly revolutionary. Four organisations from across the world, each working in their own way to provide the dignity of clean clothes, came together to weave the first threads of what would become the Global Laundry Alliance. As I moved between their conversations with my camera, capturing their words and witnessing their connections forming, I became aware that I was documenting a birth of a movement.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/2e7bba52-f468-4382-bdb5-0d9e9de158be/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">The Confluence of Rivers</h2><p id=\"\">What does it mean when people working across continents, serving different populations with similar needs, suddenly recognise themselves in each other? I watched as leaders from Orange Sky (Australia), The Washing Machine Project (UK), Ithaca Laundry (Greece), and A Drop in the Ocean (Norway) discovered their shared language—not just of laundry logistics and washing cycles, but of human dignity, of systemic barriers, of the profound significance hidden within the seemingly mundane act of washing clothes.</p><p id=\"\">The air between them crackled with recognition. These were not organisations looking to compete or compare, but fellow travellers suddenly realising they had been walking parallel paths, facing similar mountains, dreaming complementary dreams.</p><p id=\"\"><strong id=\"\">Nav (The Washing Machine Project):</strong> \"It's important to understand each other's challenges because some challenges are very similar, some are very different... I'm a connector, I'm a community builder, and I want people all around the table. My wish for communities and alliances like these is to just keep flourishing. I've found a hack in my life—which is the more you give, the more you get.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/42150cee-e831-4592-af83-ec824ff4e654/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">In the corner of Ithaca's laundry van operation, surrounded by the gentle hum of washing machines and the quiet conversations of those waiting for their clothes, Dimibra shared her vision for what this alliance could become.</p><p id=\"\"><strong id=\"\">Dimibra (Ithaca):</strong> \"For me, it's very important to have this alliance because we will enhance our impact. It will empower all organisations that try to support these people. I think it's very important to establish that hygiene is a basic human need and right. My vision—and every NGO's vision—would be to not exist because all the needs are covered.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/8e9e2ac8-d80e-4600-9a7e-c9cccc80ae32/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">The philosophical dimensions of this work emerged through my conversation with Jean Baptiste, whose experience in refugee camps brought a particular urgency to the alliance's purpose.</p><p id=\"\"><strong id=\"\">Jean Baptiste (A Drop in the Ocean):</strong> \"I think we're laying the basis of talking about laundry access and basic hygiene standards as a human right. Civil society has the strongest power and the strongest ability to actually make change. I'm a big supporter of civil society overall, and of volunteers and individuals just gathering with one another.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/8945a553-0f32-4afd-b40d-25d147b6c7ca/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">For Nic, whose journey with Orange Sky began with two washing machines in a van in Australia and has expanded across countries, the human connection remained at the centre.</p><p id=\"\"><strong id=\"\">Nic (Orange Sky):</strong> \"Behind every load of washing is a human. That's the heart of what all of these organisations have in common—people fleeing violence, people without a safe place to call home, people still manually hand-washing their clothes. And I think regardless of where you are, the opportunity to build a centre of excellence and mastery is really important.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/2ebfa632-c2b4-4c4b-8462-3471c8c745ec/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">Between Threads and Transformation</h2><p id=\"\">What emerged most clearly through these conversations was not just the practical impact of clean clothes, but the philosophical dimensions of dignity. Through the simple act of washing away dirt, these organizations are simultaneously washing away boundaries—between helper and helped, between charity and rights, between isolated intervention and systemic change.</p><p id=\"\">As Marillie, Operations Coordinator at Ithaca, eloquently put it:</p><p id=\"\">\"I think that a lot of people forget that hygiene and clean clothes are very important because we always talk about other services that they should have access to. But clean clothes is the first step for reintegrating into society. If they don't have clean clothes, they won't get interviews, they won't be able to operate in everyday life. It's important to raise awareness on how important it is to have clean clothes, to be hygienic, in order to have dignity in general in your life.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/c42e3f71-e97a-4035-9bc5-19d37dbeaac3/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">I watched as these change-makers moved from sharing operational challenges to envisioning a world where the simple dignity of clean clothes is not privilege but birthright. Their collaborative spirit created an electricity in the room—a sense that by coming together, creating something whose whole exceeded the sum of its parts.</p><h2 id=\"\">The Gentle Revolution</h2><p id=\"\">What I witnessed in Athens was the beginning of a gentle revolution—one that spins not on grand proclamations but on washing machine cycles, that measures progress not in policy changes alone but in the quiet confidence of someone wearing clean clothes to a job interview, that recognises transformation happens simultaneously at personal and systemic levels.</p><p id=\"\">The Global Laundry Alliance represents a profound form of systems-thinking-in-action. These organisations understand that behind the seemingly simple act of washing clothes lies a complex web of interconnected systems—dignity infrastructure, economic barriers, cultural narratives, governance failures. By aligning their diverse approaches while honoring contextual differences, they are creating a tapestry of transformation that can adapt to different environments while maintaining its essential pattern.</p><p id=\"\">Their decentralised approach offers a powerful model for social change in our complex world. Rather than attempting to impose a single solution, they are creating a network of approaches that can respond to local conditions while connecting to global learning. This is systems change at its most human—recognising that transformation happens not through top-down dictates but through interconnected ripples of action, reflection, and adaptation.</p><p id=\"\">As Jonathan from A Drop in the Ocean reflected:</p><p id=\"\">\"It's these grassroots movements that are bringing this discussion to bigger institutional partners. These movements and organisations are seeing from their grassroots operations that this is a huge need, and we're trying to grab the attention of people that this should be something that we can strive for and secure for people.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/ad385431-7d20-40ee-b153-f22aa164c5b0/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">Between threads and transformation lies a world reimagined—where something as fundamental as clean clothes becomes not privilege but birthright, where dignity flows as freely as water through washing machines, where the boundaries between helper and helped dissolve into the recognition of our shared humanity.</p><p id=\"\">The Global Laundry Alliance stands as testament to what becomes possible when we recognise that we are better together—that our individual efforts, when woven into collective action, create not just impact but meaning, not just services but solidarity, not just solutions but the seeds of systemic transformation.</p><p id=\"\">I left Athens with my camera full of images and my heart full of hope—for what these organisations will continue to build together, and for what their model of collaborative, dignity-centred, systems-aware change offers our fragmented world.</p><p id=\"\">Between what is and what could be, they are weaving new possibilities—one wash cycle at a time.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/ebe5cc9b-7cfc-4db2-a126-3368b7fa4fa7/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/20642763-8f78-47e5-ac77-dfc99ec372db/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/003a0c68-449b-4869-b188-ed2a9abbbf15/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/7580de4d-f25b-480e-8edc-3e21eb648668/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure>",
+      "excerpt": "From the moment A Curious Tractor sowed its first seeds, we've been dedicated to cultivating a culture of curiosity, creativity, and authenticity. Now, we're excited to introduce a new value to our fertile field - Raucousness.",
+      "content": "<p id=\"\">From the moment A Curious Tractor sowed its first seeds, we've been dedicated to cultivating a culture of curiosity, creativity, and authenticity. Now, we're excited to introduce a new value to our fertile field - Raucousness.</p><p id=\"\">It's a word that tends to get a bad rap.</p><blockquote id=\"\">But what if I told you that a little bit of raucousness could be a good thing?</blockquote><p id=\"\">Let's start from the beginning. The word 'raucous' has a rich history. Derived from the Latin word \"raucus\", it originally meant \"hoarse\". Over time, it came to represent anything loud, rowdy, or disorderly. But I propose a new interpretation of the word. One that goes beyond the negative connotations and celebrates the spirit of enthusiasm, exuberance, and infectious energy.</p><p id=\"\">Picture this. A team meeting where ideas are being thrown around like confetti, voices competing to be heard, laughter filling the room. A raucous meeting, yes, but one filled with creativity, passion, and unbridled energy. A raucousness that encourages us to step out of our comfort zones, to speak up, to engage, to challenge, and to be challenged.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1456px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1456px\"><div><img src=\"https://empathyledger.com/api/media/d7dd9c4f-bbdd-483f-9fc6-1848ec454c82/file\" loading=\"lazy\"></div><figcaption>Something we cooked up earlier</figcaption></figure><p id=\"\">Incorporating raucousness into our values at A Curious Tractor doesn't mean we're advocating for chaos or disorder. It is really the opposite. We want to foster an environment where this energised, lively spirit is harnessed and directed towards productive, creative ends. To this end, we are advocating for a kind of structured raucousness – a raucousness that has a box, that knows its limits.</p><blockquote id=\"\">But how do we strike that balance? How do we ensure that our raucous spirit doesn't spill over into disorder?</blockquote><p id=\"\">Testing our assumptions is key. We will start small, introducing elements of raucousness into brainstorming sessions, and external activities. We will then gather feedback, adjust, and improve. Does our raucous spirit encourage participation or stifle it? Does it foster creativity or create chaos? By closely monitoring these dynamics, we can calibrate the level of raucousness to suit our needs.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/e723c54f-cc2b-4bb1-ac13-f8c5d5b9062c/file\" loading=\"lazy\"></div><figcaption>Nico just getting it done</figcaption></figure><p id=\"\">There's a certain beauty in raucousness. It's the beauty of human emotion, of passion, of the desire to be heard. It's the beauty of engagement, of not just participating but being deeply involved. It's the beauty of a vibrant, thriving community.</p><p id=\"\">As we embark on this raucous revolution, I invite you all to join us. Bring your ideas, your passion, your voice. Help us make A Curious Tractor an energetic community that thrives on the shared passion of its community.</p><p id=\"\">Because everyone needs a little bit of raucousness in their lives. And at A Curious Tractor, we're ready to cultivate it.</p>",
       "authorName": "Benjamin Knight",
       "authorBio": null,
       "articleType": "editorial",
@@ -1247,74 +585,42 @@
       "relatedProjects": [
         "act-main"
       ],
-      "relatedProjectSlugs": [
-        "goods-on-country"
-      ],
+      "relatedProjectSlugs": [],
       "publishedAt": "2026-01-09T23:40:59.476+00:00",
       "createdAt": null,
       "updatedAt": null,
       "tags": [],
       "themes": [],
-      "featuredImageUrl": "https://empathyledger.com/api/media/2e7bba52-f468-4382-bdb5-0d9e9de158be/file",
+      "featuredImageUrl": "https://empathyledger.com/api/media/d7dd9c4f-bbdd-483f-9fc6-1848ec454c82/file",
       "featuredImageAlt": null,
       "storyteller": {
         "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
         "slug": "benjamin-knight",
         "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
+        "avatarUrl": null,
         "bio": null
       },
       "media": {
-        "photoCount": 11,
+        "photoCount": 2,
         "videoCount": 0,
         "photoPreviews": [
           {
-            "url": "https://empathyledger.com/api/media/2e7bba52-f468-4382-bdb5-0d9e9de158be/file",
+            "url": "https://empathyledger.com/api/media/d7dd9c4f-bbdd-483f-9fc6-1848ec454c82/file",
             "title": null,
             "alt_text": null
           },
           {
-            "url": "https://empathyledger.com/api/media/42150cee-e831-4592-af83-ec824ff4e654/file",
+            "url": "https://empathyledger.com/api/media/e723c54f-cc2b-4bb1-ac13-f8c5d5b9062c/file",
             "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/8e9e2ac8-d80e-4600-9a7e-c9cccc80ae32/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/8945a553-0f32-4afd-b40d-25d147b6c7ca/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/2ebfa632-c2b4-4c4b-8462-3471c8c745ec/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/c42e3f71-e97a-4035-9bc5-19d37dbeaac3/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/ad385431-7d20-40ee-b153-f22aa164c5b0/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
-          },
-          {
-            "url": "https://empathyledger.com/api/media/ebe5cc9b-7cfc-4db2-a126-3368b7fa4fa7/file",
-            "title": null,
-            "alt_text": "__wf_reserved_inherit"
+            "alt_text": null
           }
         ],
         "videoPreviews": []
       },
       "ctas": [],
       "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/the-tapestry-of-dignity-witnessing-the-birth-of-the-global-laundry-alliance",
-      "localPath": "/stories/the-tapestry-of-dignity-witnessing-the-birth-of-the-global-laundry-alliance",
+      "canonicalUrl": "https://empathyledger.com/articles/the-raucous-revolution",
+      "localPath": "/stories/the-raucous-revolution",
       "syndicationDestinations": [
         "act_el"
       ]
@@ -1347,7 +653,7 @@
         "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
         "slug": "benjamin-knight",
         "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
+        "avatarUrl": null,
         "bio": null
       },
       "media": {
@@ -1399,7 +705,7 @@
       },
       "ctas": [],
       "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/conversation-camp",
+      "canonicalUrl": "https://empathyledger.com/articles/conversation-camp",
       "localPath": "/stories/conversation-camp",
       "syndicationDestinations": [
         "act_el"
@@ -1431,7 +737,7 @@
         "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
         "slug": "benjamin-knight",
         "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
+        "avatarUrl": null,
         "bio": null
       },
       "media": {
@@ -1463,8 +769,332 @@
       },
       "ctas": [],
       "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/naidoc-with-jimmy",
+      "canonicalUrl": "https://empathyledger.com/articles/naidoc-with-jimmy",
       "localPath": "/stories/naidoc-with-jimmy",
+      "syndicationDestinations": [
+        "act_el"
+      ]
+    },
+    {
+      "id": "8ea6d576-a9a1-4df8-8e54-0f44de2bce92",
+      "title": "At the Speed of Ceremony: Learning Partnership on Palm Island",
+      "slug": "at-the-speed-of-ceremony-learning-partnership-on-palm-island",
+      "subtitle": null,
+      "excerpt": "This story captures a transformative journey to Palm Island, where the process of building beds becomes a powerful metaphor for community connection, cultural respect, and regeneration.",
+      "content": "<figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:8192px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"8192px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/8c9860bb-4a0b-4706-8516-a6903dc81968/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Palm Island from the air on a sunrise trip with Richard Cassidy Day 2</em></strong></figcaption></figure><p id=\"\">The journey began in Melbourne's pre-dawn stillness, marking the end of a week-and-a-half traveling with the AIME troupe from Sydney. Over coffee with Willow from Regen Network, we spun possibilities around Australia's story of place—how regeneration and local knowledge might intertwine to create something new, yet anchored in ancient wisdom.</p><p id=\"\">Brisbane offered a brief but essential pause with family. We shared food, stories, and laughter. I offered gifts, small tokens of respect for their patience as I traverse Australia, connecting with communities. The privilege of such a supportive family isn't lost on me—it’s both a blessing and a responsibility.</p><p id=\"\">Arriving in Townsville at 4:15pm, I was thrust into a race against time. The car hire system was down (30 minutes lost), Bunnings couldn’t find the crates (another 20 minutes), and Kmart became a blur of mattress protectors and squeaky trolley wheels. At 5:55pm, success—the crates were finally loaded into the ute. After a quick dip at the hotel, I collected Nic from the airport, our new mattress topper from Zinus in hand. We fell asleep thinking of the ten beds waiting to be built with Palm Island’s community members.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1068px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1068px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/01b87716-ffbf-43e6-a2cc-e78150f1bee1/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Creates and the ute</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:808px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"808px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/8ea5d93b-e148-4945-a154-a4d4573e940f/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">All loaded up with mattress protectors and creates</em></strong></figcaption></figure><p id=\"\">The flight over to Palm Island revealed the landscape like a painting—coral glinting beneath clear waters, lush greenery, and waves softly brushing the shore. I felt the weight of the journey as I lugged my bag toward Butler Bay, hoping to find an Orange Sky shift that wasn’t there. With no phone service, I trekked back to the airport, sweaty but laughing, eventually catching a ride with the CDP crew into town.</p><p id=\"\">When Nic arrived on the barge with the crates, we hit the ground running. Our first stop was the PCYC, where conversations about youth justice and entrepreneurial skills sparked ideas for young people to be involved in building beds. The Sergeant's enthusiasm opened doors to possibilities we hadn’t anticipated.</p><p id=\"\">At the Rangers' station, we reunited with Richard Cassidy, whose work connects the wisdom of traditional practices with modern tools. The MinggaMingga Land and Sea rangers look after land and sea country surrounding the Palm group of islands, including Great Palm and Orpheus islands, within the Great Barrier Reef World Heritage Area. Their work includes surveying and managing cultural heritage sites, sharing traditional knowledge through on-country activities, monitoring seagrass, coral reefs, and fish species in partnership with researchers, participating in fire management for habitat protection, and managing feral animals and weeds across the islands. Engaging with Elders and key partners, the rangers facilitate progress on caring for country priorities. Nic and I have known Richard for years—myself through Corrective Services and Nic through Orange Sky. Together, we talked about the importance of drone mapping for regeneration projects, using controlled burns and water management. The Rangers' work highlights how different knowledge systems can collaborate, each amplifying the other.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/05c54742-b3a1-4186-b89b-e853877558b5/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Nic and Richard</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/eb9bf84f-085c-4e11-977d-aa3606ddd8a6/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">The young rangers trying out a Greate Bed</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/31b62b69-0ff8-44eb-9cd9-5039d1e7ec34/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Some drone training on day 2 with the young rangers</em></strong></figcaption></figure><p id=\"\">Each bed we built told its own story. Jason, our first recipient, helped with the assembly in his driveway, fascinated by the simplicity. Nic caught up with him as he was getting on the barge, and Jason was beyond excited about his last night's sleep, eager for others to experience the same comfort. Tamika was a glowing advocate, grabbing her neighbours to emphasise how they should try out the bed, proudly showing it off in her house. </p><p id=\"\">Back in the middle of town, the son of a lady who had run the local store for many years gave us a tour, talking us through the challenges of buying a mattress and bed frame on the island. The available options were both very expensive and of poor quality, and shipping from the mainland added even more cost. We looked at the prices in the store and were shocked to see a $469 price tag for a double frame and $479 for the mattress. We learned about the realities of isolation—with frequent breakages of white goods, and the logistical challenges of returns to the mainland.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/38a0ba7f-a422-479d-972e-11181dc485e4/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Making a bed with Jason</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/b764ccb9-22de-4374-908b-66b3ab51e540/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Jason give the thumbs up of approval for his new bed</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/c12cf0e8-6d55-44ff-90c0-2ee5f3b8139e/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Tamika and her new bed freshly made</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1064px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1064px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/aba89e19-755a-4523-b1c9-a9b71967eefc/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">The local store bed ticket prices</em></strong></figcaption></figure><p id=\"\">On the morning of Day 2, the Welcome to Country ceremony at the Story Tree grounded our work in something deeper. Young rangers tended the fire while Uncle Alan Palm Island shared language and story. It was a profound experience for us, with Richard and Uncle Alan helping us feel genuinely welcomed. The young rangers, some participating in the process for the first time, carried out their roles under the watchful eyes of Uncle Alan and Richard. It was incredible to witness and be part of the process of protocol, knowing that each step we took together strengthened our ties and built stronger relationships. The smoke ceremony wasn’t just ritual—it was process, a reminder that meaningful partnership begins with respect for protocol and place. </p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:1333px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"1333px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/7dcc53f9-7168-48b6-ad40-66d1106221a6/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Alan Palm Island</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/a7fc3e97-ea5b-414d-ab67-e250c410564a/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">The full team in front of the story tree</em></strong></figcaption></figure><p id=\"\">Afterward, Uncle Alan took us to the hospital to show us his painting on the wall, representing stories from his Elders about the island, canoes, and knowledge passed down for thousands of years. He then guided us to the council boardroom, where a traditional canoe was proudly displayed. This was the very canoe that his Elders had used to traverse to the mainland for trade and relations over thousands of years, a tangible symbol of connection, resilience, and the long history of cultural exchange.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/012a6bc6-46b8-442e-8cdb-00c995e06ac7/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Uncle Alan Palm Island and his paintings on the wall of the hospital</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/526c9d6c-7a56-49b0-b020-46be529df1d4/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">The full painting and incredible story</em></strong></figcaption></figure><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/a961a842-8aec-49c0-883d-ff2b90ace736/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">A&nbsp;traditional canoe sitting in the council meeting room</em></strong></figcaption></figure><p id=\"\">Our days filled with practical work and testing. Each night, Nic and I alternated between a traditional bed and our own creation at Club Kuta, assessing sleep quality and noting adjustments to improve comfort. We focused on refining our designs, adjusting mattress firmness, and ensuring ease of assembly. Every evening was an opportunity to reflect on the day's progress, tweaking our prototypes to better suit the needs of the community. These small changes were crucial to developing something that was not only practical but also comfortable and durable.</p><p id=\"\">One&nbsp;Day 3, I had the chance to experience ranger Whatta’s mangrove education session with the schoolchildren. It showed how deeply environmental knowledge resonates when it’s shared in context and culture. The young rangers, who had themselves learned from Elders, were now passing that knowledge on to the children—teaching them about the significance of mangroves, the delicate balance of their ecosystems, and the role they play in coastal health. It was inspiring to witness this cycle of knowledge, with the young rangers stepping confidently into teaching roles while the children absorbed every word, their curiosity piqued by hands-on learning. The sense of continuity, of knowledge being passed through generations, reinforced the importance of our work and the relationships we were nurturing.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/36ec1d28-6f90-479f-b83e-96ebd11ac8b3/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">Park Ranger Whatta with the class talking mangroves</em></strong></figcaption></figure><p id=\"\">A conversation with Eva Haines, Deputy Chief Executive Officer at Palm Island Aboriginal Shire Council, extended earlier discussions we'd had about the Christmas Cup football carnival. Just a few days earlier, others had suggested we propose the bed initiative to the council. This conversation opened up the idea of using the beds at the upcoming Christmas Cup football carnival—a real-world test and a chance for young people to earn money through bed assembly. Practical opportunities like these can often plant the seeds of sustainable change.</p><p id=\"\">As my plane lifted off on day four, the markers of progress were clear: ten beds crafted and distributed, each providing valuable feedback; a partnership with the Rangers that stretches beyond furniture to include drone mapping for cultural site documentation; and an ambitious plan with the PCYC to engage young people in social enterprise. The Christmas Cup looms as our next milestone—100 beds to be assembled in early December, a testament to the community’s trust and vision. Ongoing connections with Elders like Alan Palm Island remind us that true progress moves at the speed of ceremony, not commerce.</p><p id=\"\">We know we’ll make mistakes, that our feet will stumble on paths we’re still learning to walk. But in each bed built, each conversation shared, each ceremony attended, we’re learning to be better allies, better listeners, better partners in a journey that’s been too long one-sided. In the end, it’s not about the beds—it’s about creating space for local knowledge to flourish, for cultural intelligence to lead, for communities to write their own stories of regeneration and growth.</p><p id=\"\">This truth echoes across our work in Kalgoorlie, the Lower Gulf, Alice Springs and Tennet Creek. It’s present in every prototype we test, every community meeting we attend, every protocol we follow. As the mainland approached, I thought of all we’d left behind—beds that would cradle dreams, conversations that would spark change, connections that would grow like mangrove roots, strong and vital. In my notebook, I wrote not of metrics or timelines, but of privilege and responsibility, of the honour of being invited into stories far older than our own, and of the hope that, in our small way, we’re helping write new chapters that honour the old.</p><p id=\"\">Because true revolution isn’t delivered on a barge or measured in bed frames. It grows in the spaces between ceremony and practical action, between ancient wisdom and modern needs, between listening and doing. It’s found in the moment a young ranger shares knowledge with children, in the pride of a community member assembling furniture, in the simple act of following protocol before any work begins.</p><p id=\"\">This is the path forward—one that bridges the practical with the profound, that measures success not just in units delivered but in relationships strengthened. Each flat-pack bed is an opportunity for connection, each assembly a chance for empowerment, each visit a step in a journey of mutual respect and understanding.</p><p id=\"\">One bed, one connection, one story at a time.</p><p id=\"\"><em id=\"\">BK</em></p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/875c0e44-9b24-4f8a-a5a0-81f29d1f2101/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div><figcaption id=\"\"><strong id=\"\"><em id=\"\">A Butler Bay sunrise on Day 3</em></strong></figcaption></figure>",
+      "authorName": "Benjamin Knight",
+      "authorBio": null,
+      "articleType": "editorial",
+      "primaryProject": "act-main",
+      "relatedProjects": [
+        "act-main"
+      ],
+      "relatedProjectSlugs": [
+        "goods-on-country"
+      ],
+      "publishedAt": "2026-01-09T23:40:59.476+00:00",
+      "createdAt": null,
+      "updatedAt": null,
+      "tags": [],
+      "themes": [],
+      "featuredImageUrl": "https://empathyledger.com/api/media/8c9860bb-4a0b-4706-8516-a6903dc81968/file",
+      "featuredImageAlt": null,
+      "storyteller": {
+        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
+        "slug": "benjamin-knight",
+        "displayName": "Benjamin Knight",
+        "avatarUrl": null,
+        "bio": null
+      },
+      "media": {
+        "photoCount": 17,
+        "videoCount": 0,
+        "photoPreviews": [
+          {
+            "url": "https://empathyledger.com/api/media/8c9860bb-4a0b-4706-8516-a6903dc81968/file",
+            "title": null,
+            "alt_text": null
+          },
+          {
+            "url": "https://empathyledger.com/api/media/01b87716-ffbf-43e6-a2cc-e78150f1bee1/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/8ea5d93b-e148-4945-a154-a4d4573e940f/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/05c54742-b3a1-4186-b89b-e853877558b5/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/eb9bf84f-085c-4e11-977d-aa3606ddd8a6/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/31b62b69-0ff8-44eb-9cd9-5039d1e7ec34/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/38a0ba7f-a422-479d-972e-11181dc485e4/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/b764ccb9-22de-4374-908b-66b3ab51e540/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          }
+        ],
+        "videoPreviews": []
+      },
+      "ctas": [],
+      "visibility": "public",
+      "canonicalUrl": "https://empathyledger.com/articles/at-the-speed-of-ceremony-learning-partnership-on-palm-island",
+      "localPath": "/stories/at-the-speed-of-ceremony-learning-partnership-on-palm-island",
+      "syndicationDestinations": [
+        "act_el"
+      ]
+    },
+    {
+      "id": "75101fd0-9501-4edb-a511-6fb3fbcef8e9",
+      "title": "Dear Souls Adrift in this Vast Expanse",
+      "slug": "its-overwhelming-isnt-it",
+      "subtitle": null,
+      "excerpt": "It's overwhelming, isn't it?",
+      "content": "<h2 data-sp-article=\"PP4KPPDEZ.10\" id=\"23c33df3-e44a-4ebc-85d4-6b2f0d87a11a\">Dear Souls Adrift in this Vast Expanse</h2><p>In a world that oscillates between the cacophony of dissent and the silence of compliance, there lies a narrow path. It's a path that demands the courage to speak, yet the wisdom to listen; the fortitude to act, yet the compassion to empathise. As I pen down these words, the world outside is a theatre of contradictions. Votes are being cast—simple 'yes' or 'no' checkboxes that somehow are expected to encapsulate our complex moral landscapes. Wars rage on in distant lands, their reverberations unsettling the very ground we stand upon. And here, in our microcosms, the chasm between abundance and need widens, almost as if mocking our shared humanity.</p><p>It's overwhelming, isn't it? The weight of the world's woes can stifle our voices, drown them in the sea of collective noise. We're often led astray by the cacophonous opinions of those around us, diminishing the potency of our individual voices, urging us to follow the crowd into an abyss of moral compromise.</p><p>Yet, here's the paradox: sometimes our voice, when finally unleashed, can be a double-edged sword. It can sever the ties that bind us to family, friends, and community. It can invite a torrent of vitriol, both online and in the flesh, making us question the very act of speaking out. It's a precarious balance, one that leaves us teetering on the edge of action and inaction, speech and silence.</p><p>Doing nothing is often not an option; the world's stage is not one that tolerates passive spectators. But choosing where to lend your voice, where to invest your emotional and moral capital—that is the crux. It's a choice that requires not just bravery but also empathy, the ability to step into another's shoes and see the world through a lens tinted with compassion and understanding.</p><div data-type=\"regular\" data-title=\"<p>Photo by <a href=&quot;https://unsplash.com/@fakurian?utm_source=Storipress&utm_medium=referral&utm_campaign=api-credit?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit&quot;>Milad Fakurian</a> / <a href=&quot;https://unsplash.com/?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit&quot;>Unsplash</a></p>\" data-source=\"[]\" data-link=\"\" data-style=\"\" data-alt=\"n the world we live in, every small decision can set off a chain reaction, much like dominos, influencing the significant events in our lives. Drawing inspiration from the domino effect and some of my old works that have captivated millions of viewers until today, I have redesigned this collection. I am thrilled to share it with you. If you enjoy it, feel free to tag me in your Instagram stories and share your feelings about this collection with others\" data-src=\"https://empathyledger.com/api/media/11350935-82c9-4789-9bc6-a0cf15e82605/file\" data-format=\"image\" class=\"clear-both mx-auto\"><figure><picture><img type=\"regular\" link=\"\" title=\"<p>Photo by <a href=&quot;https://unsplash.com/@fakurian?utm_source=Storipress&utm_medium=referral&utm_campaign=api-credit?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit&quot;>Milad Fakurian</a> / <a href=&quot;https://unsplash.com/?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit&quot;>Unsplash</a></p>\" alt=\"n the world we live in, every small decision can set off a chain reaction, much like dominos, influencing the significant events in our lives. Drawing inspiration from the domino effect and some of my old works that have captivated millions of viewers until today, I have redesigned this collection. I am thrilled to share it with you. If you enjoy it, feel free to tag me in your Instagram stories and share your feelings about this collection with others\" source=\"\" src=\"https://empathyledger.com/api/media/11350935-82c9-4789-9bc6-a0cf15e82605/file\"></picture><figcaption class=\"pt-2 block caption-text\"><div><p>Photo by <a href=\"https://unsplash.com/@fakurian?utm_source=Storipress&utm_medium=referral&utm_campaign=api-credit?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit\">Milad Fakurian</a> / <a href=\"https://unsplash.com/?utm_source=storipress&utm_medium=referral&utm_campaign=api-credit\">Unsplash</a></p></div></figcaption></figure></div><p>I am no oracle, no sage with answers to the world's complex questions. I am but a humble wanderer, searching for my place in this intricate web of existence. Yet, I yearn for the courage to say what I believe, to stand against the tides of popular opinion when my soul urges me to do so. And if I err, let me have the humility to admit it, for the path to wisdom is paved with the bricks of our mistakes.</p><p>So, as the world turns and decisions loom large, I cast my vote for 'Yes.' I cannot, in good conscience, support the wars tearing apart the fabric of communities in Israel and Ukraine. I beseech those in positions of power to recognize their role in sculpting a more equitable world. And above all, I hope that our dialogues can transcend the pettiness of name-calling, the futility of violence, and be imbued with the essence of empathy and understanding.</p><p>For in the end, it is not just bravery that we need, but a bravery laced with empathy—a courage that listens as much as it speaks, that acts not just with resolve but also with compassion.</p><p>With a heart full of hope and a soul yearning for peace,</p><p data-sp-article-end=\"PP4KPPDEZ.10\">A Fellow Traveler</p>\n<script async type=\"module\" src=\"https://script-providers.storipress.workers.dev/storipress.mjs?client=PP4KPPDEZ&platform=webflow\"></script>",
+      "authorName": "Benjamin Knight",
+      "authorBio": null,
+      "articleType": "editorial",
+      "primaryProject": "act-main",
+      "relatedProjects": [
+        "act-main"
+      ],
+      "relatedProjectSlugs": [],
+      "publishedAt": "2026-01-09T23:40:59.476+00:00",
+      "createdAt": null,
+      "updatedAt": null,
+      "tags": [],
+      "themes": [],
+      "featuredImageUrl": null,
+      "featuredImageAlt": null,
+      "storyteller": {
+        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
+        "slug": "benjamin-knight",
+        "displayName": "Benjamin Knight",
+        "avatarUrl": null,
+        "bio": null
+      },
+      "media": {
+        "photoCount": 0,
+        "videoCount": 0,
+        "photoPreviews": [],
+        "videoPreviews": []
+      },
+      "ctas": [],
+      "visibility": "public",
+      "canonicalUrl": "https://empathyledger.com/articles/its-overwhelming-isnt-it",
+      "localPath": "/stories/its-overwhelming-isnt-it",
+      "syndicationDestinations": [
+        "act_el"
+      ]
+    },
+    {
+      "id": "905415f9-bf80-4bd6-9495-39db2fb0a5ee",
+      "title": "CONTAINED: Where Policy Meets Flesh",
+      "slug": "contained-where-policy-meets-flesh",
+      "subtitle": null,
+      "excerpt": "Share this if you're done watching children being destroyed for profit while we pretend it's justice.",
+      "content": "<h1 id=\"\">This Isn't Another Report to Die in Your Downloads Folder</h1><p id=\"\">This is Isiah's skeleton remembering surveillance cameras. This is fluorescent light at 120 Hz living between your molars and your amygdala. This is what happens when we stop intellectualising trauma and start feeling it in our bones.</p><p id=\"\"><strong id=\"\">Three rooms. 30 minutes. The entire truth about youth justice.</strong></p><h3 id=\"\">WHY THIS EXISTS</h3><h2 id=\"\">Because I'm Drowning in the Disconnect</h2><p id=\"\">Politicians tweet about youth crime from offices they'll never leave. Million-dollar reports written by people who've never heard institutional despair. Conferences where we intellectualise children trying not to die inside.</p><p id=\"\">Meanwhile, Isiah walks into Room 1 and his shoulders tell us more truth in three seconds than every policy paper ever written.</p><p id=\"\"><em id=\"\">\"I was just watching your face and you're like, 'What the f</em>**?'\"*</p><p id=\"\">That's not shock. That's recognition. That's a body having a conversation with its past.</p><p id=\"\"><strong id=\"\">We built this container because understanding and KNOWING are different creatures entirely.</strong></p><h3 id=\"\">THE THREE ROOMS</h3><h4 id=\"\">Room 1: Brisbane's Reality</h4><p id=\"\"><em id=\"\">12 minutes of institutional truth</em></p><p id=\"\">Steel bench because <em id=\"\">\"timber could become a weapon.\"</em> Everything bolted down because <em id=\"\">\"hope gets dangerous when it's portable.\"</em> Mesh windows that turn sunlight into something industrial and impossible.</p><p id=\"\">Isiah stood here and marked these walls. Not vandalism - archaeology in reverse. Proof that young people survive these spaces despite them, not because of them.</p><p id=\"\"><strong id=\"\">This room costs $2,355 per day. Per child. To manufacture trauma.</strong></p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/9d001a37-f487-4731-9674-76e320da8c53/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><h4 id=\"\">Room 2: What We Already Know Works</h4><p id=\"\"><em id=\"\">15 minutes of radical humanity</em></p><p id=\"\">Sunset-coloured walls. Cordless phone. Family photos. Dignity made tangible.</p><p id=\"\">Isiah's assessment: <em id=\"\">\"Massive difference.\"</em></p><p id=\"\">That's it. That's the whole fucking report. One young man, two rooms, one word. Everything else is just expensive noise.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/b5f66c96-df28-4b5f-bb82-b181315bea2e/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><h4 id=\"\">Room 3: Your Commitment</h4><p id=\"\"><em id=\"\">3 minutes to stop pretending you don't know</em></p><p id=\"\">This is where you stop being a tourist in other people's trauma. Sign something. Fund something. Change something. Or admit you're comfortable with children being destroyed at $859,589 per year.</p><p id=\"\"><strong id=\"\">No exit without commitment. That's the deal.</strong></p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/3d8ee7c9-0c00-4b48-97e6-82a11e77f2ae/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><h3 id=\"\">WHO NEEDS TO WALK THROUGH</h3><h4 id=\"\">Politicians</h4><p id=\"\">Bring your tough-on-crime tweets. Leave with Isiah's scratches under your fingernails.</p><h4 id=\"\">Policymakers</h4><p id=\"\">Bring your evidence-based frameworks. Leave understanding that evidence has a nervous system.</p><h4 id=\"\">Everyone Who Says \"But What About the Victims?\"</h4><p id=\"\">Isiah WAS a victim. Then we made him one again, systematically, at taxpayer expense.</p><h4 id=\"\">You</h4><p id=\"\">Because watching this through a screen isn't enough anymore.</p><h3 id=\"\">THE ISIAH PRINCIPLE</h3><p id=\"\">After years in rooms like Room 1, Isiah said:</p><p id=\"\"><em id=\"\">\"I would prefer [people didn't] have to experience this to bring change.\"</em></p><p id=\"\">He wishes the people funding torture chambers could understand without feeling even a fraction of what he endured. That's not forgiveness - that's humanity so profound it indicts the system more than any container could.</p><p id=\"\">But his gentleness won't change policy. His wisdom won't shift budgets.</p><p id=\"\"><strong id=\"\">What might work is making you sit where he sat.</strong></p><h3 id=\"\">BUILT BY PEOPLE WHO ARE DONE TALKING</h3><p id=\"\"><strong id=\"\">Benjamin Knight</strong>: The insomniac who follows paper trails to kids in cages<br><strong id=\"\">Nicholas Marchesi</strong>: Built these containers with his hands because revolution needs carpenters<br><strong id=\"\">Isiah</strong>: Marked the walls so you can't pretend you don't know<br><strong id=\"\">Young Architects</strong>: Who survived the system and now design its replacement</p><p id=\"\">This is our middle finger to every conference that pontificates about \"trauma-informed care\" while children scratch their names into walls just to prove they exist.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/e9191057-d535-4cad-9401-573676cf87bf/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure>\n<h3>The archaeology of truth</h3>\n\n<p>Isiah picked up something sharp and started scratching the walls.</p>\n\n<p><em>\"Do it. Get some rocks,\"</em> someone said.</p>\n\n<p>This was not vandalism. It was documentation. Every scratch both wound and suture. The sound filled the container, that specific scraping every detention survivor knows, the soundtrack to carving your existence into surfaces designed to forget you.</p>\n\n<p>He knows why the bench is steel: <em>\"If it was timber, you could jump on it and make a weapon.\"</em></p>\n\n<p>He knows why everything is bolted down: <em>\"Hope gets dangerous when it's portable.\"</em></p>\n\n<p>These are not design choices. They are statements about which children are thought to have futures and which are thought to need warehousing.</p>\n\n<h3>Room 2 changed everything</h3>\n\n<p>The Spanish model. Sunset walls. A cordless phone, which means trusting a teenager with a cord. Family photographs.</p>\n\n<p>Isiah's assessment: <em>\"Massive.\"</em></p>\n\n<p>One word. That is the entire finding, and it is what a million dollar evaluation would conclude if it were willing to be plain: treating children like humans works better than treating them like hazardous waste.</p>\n\n<h2>What he did not tell you</h2>\n\n<p>Isiah grew up in Marsden, in Logan, the youngest of six. Spoiled, he says, and bullied. Outside as much as he could be, home when the street lights went off. His parents stayed loving, he is careful to say that, and they fell out with each other, and there was violence in the house, so he stayed out longer.</p>\n\n<p>He was good at school until he was not. There was no money. Everyone around him had things he did not.</p>\n\n<blockquote>You know what gets me the most? I hate jam sandwiches. I can't eat jam sandwiches now. I'll never touch a jam sandwich again.</blockquote>\n\n<p>He names the rest without excuse. The films, the music, looking for acceptance from other men and from that world. And then this, which is the clearest account of going in that anyone has given us.</p>\n\n<blockquote>While I was trying to look for acceptance, trying to be a cool guy, I jumped in too deep and then just couldn't turn back. Well, that's what I felt like. I couldn't turn back. It was like I got into the ocean and started swimming at a really young age, without taking any swimming lessons.</blockquote>\n\n<p>Ask him about being locked up and he will mostly decline. Not from shame. From strategy.</p>\n\n<blockquote>I don't talk about it at all, unless someone asks me a question. My approach is I just want to tell people about what I'm doing now and how to avoid that world. If I sit here and tell stories about my incarceration, it probably will help a lot of kids see differently. But it'll also give a lot of kids the want to go in. The want of, I need that, I need to experience that, I'm not cool enough. I don't want to put that message out there.</blockquote>\n\n<p>That is a young man refusing to let his worst years become another child's ambition. It is also a quiet judgement on how this sector usually uses people like him.</p>\n\n<h2>He helped build the room he had lived in</h2>\n\n<p>Isiah worked on Room 1. The Brisbane cell. A version of a room he had already survived, built again on purpose, so other people would have to stand in it.</p>\n\n<p>Asked why he bothered, he pointed away from himself.</p>\n\n<blockquote>It's the army I have around me. My support system. They're just real encouraging. And I don't know, bro. Why not? It's art, man.</blockquote>\n\n<p>Then he saw it finished, and it knocked him sideways.</p>\n\n<blockquote>It brought a big rush. I was freaking out. I went home, I was freaking out. And then I saw the article, and I was freaking out even more. And then I read through it, and it just hit me. And then I let my mum read it, and then she just broke down.</blockquote>\n\n<p>Fifty people came through in a day. He stood up at the Reintegration Conference as a keynote speaker, which he had never done before.</p>\n\n<blockquote>It was scary at the start. But now that it's done, I feel accomplished. I feel like I've accomplished something really big.</blockquote>\n\n<h2>What he wants you to feel</h2>\n\n<p>Asked what he wants a visitor to feel walking out, he would not give a tidy answer.</p>\n\n<blockquote>I haven't really got an answer for that. I just want them to feel something.</blockquote>\n\n<p>And asked how it feels to have his fingerprints on something this public, he moved the subject off himself entirely.</p>\n\n<blockquote>I don't really think it's about me. I'm just happy that people can see, because kids still live like that. There's still kids in the same room, in this exact room. So it doesn't matter how I feel. It's about how they feel.</blockquote>\n\n<p>That is the argument for young people leading this work, made better than the sector makes it. Not that lived experience is a credential to collect or a quote to drop into a funding application. That the person who has been in the room knows what the room does, and is the one pointing at the children still in it.</p>\n\n<h2>What happens next is not his job</h2>\n\n<p>He is not making claims about where this goes.</p>\n\n<blockquote>I think opportunities will just come as life goes. I'm just going to flow with it. Just going to keep mowing lawns till I get an email.</blockquote>\n\n<p>There is an email to be sent. It is not his job to chase it.</p>\n",
+      "authorName": "Benjamin Knight",
+      "authorBio": null,
+      "articleType": "editorial",
+      "primaryProject": "act-main",
+      "relatedProjects": [
+        "act-main"
+      ],
+      "relatedProjectSlugs": [
+        "justicehub"
+      ],
+      "publishedAt": "2026-01-09T23:40:59.476+00:00",
+      "createdAt": null,
+      "updatedAt": null,
+      "tags": [],
+      "themes": [],
+      "featuredImageUrl": "https://empathyledger.com/api/media/9d001a37-f487-4731-9674-76e320da8c53/file",
+      "featuredImageAlt": null,
+      "storyteller": {
+        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
+        "slug": "benjamin-knight",
+        "displayName": "Benjamin Knight",
+        "avatarUrl": null,
+        "bio": null
+      },
+      "media": {
+        "photoCount": 4,
+        "videoCount": 0,
+        "photoPreviews": [
+          {
+            "url": "https://empathyledger.com/api/media/9d001a37-f487-4731-9674-76e320da8c53/file",
+            "title": null,
+            "alt_text": null
+          },
+          {
+            "url": "https://empathyledger.com/api/media/b5f66c96-df28-4b5f-bb82-b181315bea2e/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/3d8ee7c9-0c00-4b48-97e6-82a11e77f2ae/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/e9191057-d535-4cad-9401-573676cf87bf/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          }
+        ],
+        "videoPreviews": []
+      },
+      "ctas": [],
+      "visibility": "public",
+      "canonicalUrl": "https://empathyledger.com/articles/contained-where-policy-meets-flesh",
+      "localPath": "/stories/contained-where-policy-meets-flesh",
+      "syndicationDestinations": [
+        "act_el"
+      ]
+    },
+    {
+      "id": "48cce05b-c7da-45d1-89a8-f5e54ff99ef2",
+      "title": "The Tapestry of Dignity: Witnessing the Birth of the Global Laundry Alliance",
+      "slug": "the-tapestry-of-dignity-witnessing-the-birth-of-the-global-laundry-alliance",
+      "subtitle": null,
+      "excerpt": "The Global Laundry Alliance represents a radical reimagining of how social change manifests—not through isolated interventions but through collective wisdom, not through competition but through collaboration, not through prescription but through possibility.",
+      "content": "<p id=\"\">In the gentle April sunshine of Athens, I witnessed something quietly revolutionary. Four organisations from across the world, each working in their own way to provide the dignity of clean clothes, came together to weave the first threads of what would become the Global Laundry Alliance. As I moved between their conversations with my camera, capturing their words and witnessing their connections forming, I became aware that I was documenting a birth of a movement.</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/2e7bba52-f468-4382-bdb5-0d9e9de158be/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">The Confluence of Rivers</h2><p id=\"\">What does it mean when people working across continents, serving different populations with similar needs, suddenly recognise themselves in each other? I watched as leaders from Orange Sky (Australia), The Washing Machine Project (UK), Ithaca Laundry (Greece), and A Drop in the Ocean (Norway) discovered their shared language—not just of laundry logistics and washing cycles, but of human dignity, of systemic barriers, of the profound significance hidden within the seemingly mundane act of washing clothes.</p><p id=\"\">The air between them crackled with recognition. These were not organisations looking to compete or compare, but fellow travellers suddenly realising they had been walking parallel paths, facing similar mountains, dreaming complementary dreams.</p><p id=\"\"><strong id=\"\">Nav (The Washing Machine Project):</strong> \"It's important to understand each other's challenges because some challenges are very similar, some are very different... I'm a connector, I'm a community builder, and I want people all around the table. My wish for communities and alliances like these is to just keep flourishing. I've found a hack in my life—which is the more you give, the more you get.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/42150cee-e831-4592-af83-ec824ff4e654/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">In the corner of Ithaca's laundry van operation, surrounded by the gentle hum of washing machines and the quiet conversations of those waiting for their clothes, Dimibra shared her vision for what this alliance could become.</p><p id=\"\"><strong id=\"\">Dimibra (Ithaca):</strong> \"For me, it's very important to have this alliance because we will enhance our impact. It will empower all organisations that try to support these people. I think it's very important to establish that hygiene is a basic human need and right. My vision—and every NGO's vision—would be to not exist because all the needs are covered.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/8e9e2ac8-d80e-4600-9a7e-c9cccc80ae32/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">The philosophical dimensions of this work emerged through my conversation with Jean Baptiste, whose experience in refugee camps brought a particular urgency to the alliance's purpose.</p><p id=\"\"><strong id=\"\">Jean Baptiste (A Drop in the Ocean):</strong> \"I think we're laying the basis of talking about laundry access and basic hygiene standards as a human right. Civil society has the strongest power and the strongest ability to actually make change. I'm a big supporter of civil society overall, and of volunteers and individuals just gathering with one another.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/8945a553-0f32-4afd-b40d-25d147b6c7ca/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">For Nic, whose journey with Orange Sky began with two washing machines in a van in Australia and has expanded across countries, the human connection remained at the centre.</p><p id=\"\"><strong id=\"\">Nic (Orange Sky):</strong> \"Behind every load of washing is a human. That's the heart of what all of these organisations have in common—people fleeing violence, people without a safe place to call home, people still manually hand-washing their clothes. And I think regardless of where you are, the opportunity to build a centre of excellence and mastery is really important.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/2ebfa632-c2b4-4c4b-8462-3471c8c745ec/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><h2 id=\"\">Between Threads and Transformation</h2><p id=\"\">What emerged most clearly through these conversations was not just the practical impact of clean clothes, but the philosophical dimensions of dignity. Through the simple act of washing away dirt, these organizations are simultaneously washing away boundaries—between helper and helped, between charity and rights, between isolated intervention and systemic change.</p><p id=\"\">As Marillie, Operations Coordinator at Ithaca, eloquently put it:</p><p id=\"\">\"I think that a lot of people forget that hygiene and clean clothes are very important because we always talk about other services that they should have access to. But clean clothes is the first step for reintegrating into society. If they don't have clean clothes, they won't get interviews, they won't be able to operate in everyday life. It's important to raise awareness on how important it is to have clean clothes, to be hygienic, in order to have dignity in general in your life.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/c42e3f71-e97a-4035-9bc5-19d37dbeaac3/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">I watched as these change-makers moved from sharing operational challenges to envisioning a world where the simple dignity of clean clothes is not privilege but birthright. Their collaborative spirit created an electricity in the room—a sense that by coming together, creating something whose whole exceeded the sum of its parts.</p><h2 id=\"\">The Gentle Revolution</h2><p id=\"\">What I witnessed in Athens was the beginning of a gentle revolution—one that spins not on grand proclamations but on washing machine cycles, that measures progress not in policy changes alone but in the quiet confidence of someone wearing clean clothes to a job interview, that recognises transformation happens simultaneously at personal and systemic levels.</p><p id=\"\">The Global Laundry Alliance represents a profound form of systems-thinking-in-action. These organisations understand that behind the seemingly simple act of washing clothes lies a complex web of interconnected systems—dignity infrastructure, economic barriers, cultural narratives, governance failures. By aligning their diverse approaches while honoring contextual differences, they are creating a tapestry of transformation that can adapt to different environments while maintaining its essential pattern.</p><p id=\"\">Their decentralised approach offers a powerful model for social change in our complex world. Rather than attempting to impose a single solution, they are creating a network of approaches that can respond to local conditions while connecting to global learning. This is systems change at its most human—recognising that transformation happens not through top-down dictates but through interconnected ripples of action, reflection, and adaptation.</p><p id=\"\">As Jonathan from A Drop in the Ocean reflected:</p><p id=\"\">\"It's these grassroots movements that are bringing this discussion to bigger institutional partners. These movements and organisations are seeing from their grassroots operations that this is a huge need, and we're trying to grab the attention of people that this should be something that we can strive for and secure for people.\"</p><figure id=\"\" class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div id=\"\"><img src=\"https://empathyledger.com/api/media/ad385431-7d20-40ee-b153-f22aa164c5b0/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\" width=\"auto\" height=\"auto\" id=\"\"></div></figure><p id=\"\">Between threads and transformation lies a world reimagined—where something as fundamental as clean clothes becomes not privilege but birthright, where dignity flows as freely as water through washing machines, where the boundaries between helper and helped dissolve into the recognition of our shared humanity.</p><p id=\"\">The Global Laundry Alliance stands as testament to what becomes possible when we recognise that we are better together—that our individual efforts, when woven into collective action, create not just impact but meaning, not just services but solidarity, not just solutions but the seeds of systemic transformation.</p><p id=\"\">I left Athens with my camera full of images and my heart full of hope—for what these organisations will continue to build together, and for what their model of collaborative, dignity-centred, systems-aware change offers our fragmented world.</p><p id=\"\">Between what is and what could be, they are weaving new possibilities—one wash cycle at a time.</p><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/ebe5cc9b-7cfc-4db2-a126-3368b7fa4fa7/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/20642763-8f78-47e5-ac77-dfc99ec372db/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/003a0c68-449b-4869-b188-ed2a9abbbf15/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure><figure class=\"w-richtext-figure-type-image w-richtext-align-fullwidth\" style=\"max-width:2000px\" data-rt-type=\"image\" data-rt-align=\"fullwidth\" data-rt-max-width=\"2000px\"><div><img src=\"https://empathyledger.com/api/media/7580de4d-f25b-480e-8edc-3e21eb648668/file\" loading=\"lazy\" alt=\"__wf_reserved_inherit\"></div></figure>",
+      "authorName": "Benjamin Knight",
+      "authorBio": null,
+      "articleType": "editorial",
+      "primaryProject": "act-main",
+      "relatedProjects": [
+        "act-main"
+      ],
+      "relatedProjectSlugs": [
+        "goods-on-country"
+      ],
+      "publishedAt": "2026-01-09T23:40:59.476+00:00",
+      "createdAt": null,
+      "updatedAt": null,
+      "tags": [],
+      "themes": [],
+      "featuredImageUrl": "https://empathyledger.com/api/media/2e7bba52-f468-4382-bdb5-0d9e9de158be/file",
+      "featuredImageAlt": null,
+      "storyteller": {
+        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
+        "slug": "benjamin-knight",
+        "displayName": "Benjamin Knight",
+        "avatarUrl": null,
+        "bio": null
+      },
+      "media": {
+        "photoCount": 11,
+        "videoCount": 0,
+        "photoPreviews": [
+          {
+            "url": "https://empathyledger.com/api/media/2e7bba52-f468-4382-bdb5-0d9e9de158be/file",
+            "title": null,
+            "alt_text": null
+          },
+          {
+            "url": "https://empathyledger.com/api/media/42150cee-e831-4592-af83-ec824ff4e654/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/8e9e2ac8-d80e-4600-9a7e-c9cccc80ae32/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/8945a553-0f32-4afd-b40d-25d147b6c7ca/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/2ebfa632-c2b4-4c4b-8462-3471c8c745ec/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/c42e3f71-e97a-4035-9bc5-19d37dbeaac3/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/ad385431-7d20-40ee-b153-f22aa164c5b0/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          },
+          {
+            "url": "https://empathyledger.com/api/media/ebe5cc9b-7cfc-4db2-a126-3368b7fa4fa7/file",
+            "title": null,
+            "alt_text": "__wf_reserved_inherit"
+          }
+        ],
+        "videoPreviews": []
+      },
+      "ctas": [],
+      "visibility": "public",
+      "canonicalUrl": "https://empathyledger.com/articles/the-tapestry-of-dignity-witnessing-the-birth-of-the-global-laundry-alliance",
+      "localPath": "/stories/the-tapestry-of-dignity-witnessing-the-birth-of-the-global-laundry-alliance",
+      "syndicationDestinations": [
+        "act_el"
+      ]
+    },
+    {
+      "id": "30f9717c-77bc-4e55-8756-c5cd1e310c2b",
+      "title": "The Weight of Silence and the Audacity to Imagine: Reflections on Fear, Hope, and the Long Game of Human Liberation",
+      "slug": "the-weight-of-silence-and-the-audacity-to-imagine-reflections-on-fear-hope-and-the-long-game-of-human-liberation",
+      "subtitle": null,
+      "excerpt": "This is Part 1 of an ongoing series exploring the intersection of personal transformation and systemic change. A Curious Tractor exists to create spaces for this kind of collective reimagining—working with organisations and communities ready to move beyond fixing broken systems toward building entirely new ones. Join the conversation by sharing your own reflections on how we might build communities organised around healing rather than harm. Drop a comment, share your story, challenge my thinking let's explore what becomes possible when we dare to imagine differently.",
+      "content": "<p id=\"\">‍<em id=\"\">In this moment of profound transition, we stand at the intersection of possibility and potential and I've been struggling with the weight of what I see unfolding around us.</em></p><p id=\"\">I've been quiet lately. Not absent, but quiet in the way that deep waters run silent, processing, witnessing, feeling the collective pull toward conversations that diminish rather than expand our humanity. Every government press release celebrating another youth arrest, every politician performing \"tough on crime\" theatre, every comment thread dissolving into tribal warfare over who deserves safety and who deserves punishment feels like watching a society choose the smallest version of itself.</p><p id=\"\"><em id=\"\">And I've been asking myself: How do we speak truth into a world that seems increasingly committed to its own mythology of scarcity and separation?</em></p><h2 id=\"\">The Personal Ecology of Systemic Transformation</h2><p id=\"\">My journey into this work didn't begin with policy papers or budget analyses. It began, as most authentic transformations do, in the messy intersection of personal experience and collective awakening. Years of youth work taught me that the young people society labels as \"problems\" are often our greatest teachers - mirrors reflecting back the systems that have failed them, the communities that have abandoned them, the adults who have forgotten what it means to see potential in the face of pain.</p><p id=\"\"><em id=\"\">Our mountains are both institutional and internal - requiring courage, vulnerability, and an unwavering commitment to seeing beyond current limitations.</em></p><p id=\"\">This understanding eventually led me to create A Curious Tractor. Not because the world needed another consulting business, but because I kept encountering organisations, communities, and leaders who were asking the same fundamental question: <em id=\"\">How do we build something different when we're trapped inside systems designed for a world that no longer serves us?</em></p><p id=\"\">A Curious Tractor emerged from a simple recognition: that most of our approaches to change - whether in youth justice, organisational development, or community transformation - are still rooted in the same mechanistic thinking that created the problems we're trying to solve. We're trying to fix broken systems using the same logic that broke them in the first place.</p><p id=\"\"><em id=\"\">What if the path forward requires not just different strategies, but entirely different ways of thinking about change itself?</em></p><p id=\"\">The work we do through A Curious Tractor is about creating spaces for collaborative learning and development that honour the complexity of human systems. It's about working with organisations and communities to build capacity for transformation from the inside out. It's about recognising that sustainable change isn't something we do <em id=\"\">to</em> systems, it's something that emerges <em id=\"\">from</em> systems when we create the conditions for collective reimagining.</p><p id=\"\"><em id=\"\">We are not just participants, but architects of a new paradigm. Each conversation, each connection becomes a thread in a larger tapestry of collective reimagining.</em></p><p id=\"\">Every engagement, whether with a community organisation struggling to serve complex needs or a corporation trying to navigate rapid change, becomes an opportunity to practice what we preach: that transformation happens through relationship, that wisdom emerges from collective inquiry, that the solutions we need already exist within the communities experiencing the challenges.</p><h2 id=\"\">The Weight of Contradiction</h2><p id=\"\">But here's what keeps me awake at night: while we're working with organisations to embrace collaborative learning, vulnerability, and systemic thinking, the broader society seems to be moving in the opposite direction. While we're helping leaders understand that complex challenges require collective wisdom, our political systems are celebrating simplistic solutions to multifaceted problems.</p><p id=\"\"><em id=\"\">How do you maintain hope while watching a state spend $859,589 annually to warehouse each child in detention, knowing that the same money could transform thousands of young lives through the kind of collaborative, healing-centred approaches we know actually work?</em></p><p id=\"\">The mathematics are staggering in their moral clarity:</p><ul id=\"\"><li id=\"\">$318+ million spent on a youth justice system with a 68% failure rate</li><li id=\"\">22-33 times higher detention rates for Indigenous children</li><li id=\"\">Youth crime representing only 13% of total crime while consuming disproportionate resources</li><li id=\"\">Community programs that work receiving table scraps while detention infrastructure gets hundreds of millions</li></ul><p id=\"\"><em id=\"\">But the numbers, devastating as they are, tell only part of the story.</em></p><p id=\"\">What breaks my heart is witnessing the cognitive dissonance between what we know works in human development and what we continue to fund in public policy. Every day through A Curious Tractor, we see organisations discovering that when you create conditions for authentic collaboration, when you honour the wisdom present in every community, when you design systems around human flourishing rather than control and compliance, remarkable transformations become possible.</p><p id=\"\"><em id=\"\">Yet these same insights which seem obvious in organisational development contexts become radical impossibilities when applied to criminal justice, education, or social services.</em></p><h2 id=\"\">The Conversation We're Not Having</h2><p id=\"\">The public discourse around youth justice has become a carefully choreographed dance of moral posturing that avoids the questions that matter most:</p><p id=\"\"><em id=\"\">What kind of society do we want to be? What do we believe about human nature and the possibility for transformation?What are we actually protecting, and what are we actually destroying? How do we measure success in a system designed to heal rather than harm?</em></p><p id=\"\">Through A Curious Tractor's work, we've seen what happens when organisations are brave enough to engage these deeper questions. We've watched teams discover that their most entrenched conflicts contain the seeds of their greatest breakthroughs. We've facilitated processes where communities in crisis become laboratories for innovation. We've witnessed leaders learn that vulnerability isn't weakness it's the foundation of authentic authority.</p><p id=\"\"><em id=\"\">The most unsafe thing we can do is continue investing in approaches that create more trauma, more disconnection, more cycles of harm.</em></p><p id=\"\">But these lessons, which feel revolutionary in organisational contexts, are exactly what Indigenous communities have been practicing for thousands of years, what restorative justice practitioners have been demonstrating for decades, what countries like Portugal and Norway have been proving at scale for years.</p><p id=\"\"><em id=\"\">The question is not whether transformation is possible. The question is whether we have the courage to choose it.</em></p><h2 id=\"\">The Practice of Collective Transformation</h2><p id=\"\">Every engagement with A Curious Tractor becomes an experiment in applied hope. Spaces where power is shared rather than hoarded. Processes where wisdom emerges from collective inquiry rather than individual expertise. Approaches where healing and productivity aren't in competition but are recognized as interdependent.</p><p id=\"\">When we facilitate strategic planning processes that begin with personal reflection and end with collective commitment, we're practicing the integration of inner and outer transformation. When we design learning experiences that honour both individual growth and systemic change, we're modelling what becomes possible when we stop treating personal development and social justice as separate endeavors.</p><p id=\"\"><em id=\"\">Every breakthrough begins with the audacity to imagine differently.</em></p><p id=\"\">But I'm tired of this work existing only in the margins, only in the spaces where people already believe transformation is possible. I'm frustrated that the insights emerging from collaborative learning processes aren't informing how we design criminal justice systems, education policies, or community response to crisis.</p><p id=\"\">This is why I've been quiet. Not because I've lost hope, but because I've been feeling the full weight of what we're choosing as individuals, as communities, as a society. <em id=\"\">In this moment of profound transition, we stand at the intersection of possibility and potential and we're choosing fear.</em></p><p id=\"\">I see a nation so privileged, so resourced, so capable of profound transformation, and we're being drawn into conversations that divide rather than unite, that diminish rather than expand, that close possibilities rather than open them. We're talking about protecting \"what's ours\" without examining what ownership means in a world where Indigenous children are detained at rates that can only be described as systematically genocidal.</p><p id=\"\"><em id=\"\">What are we actually hoarding when we hoard wealth, safety, opportunity? What are we actually protecting when we build walls instead of bridges? What are we actually achieving when winning arguments becomes more important than healing communities?</em></p><p id=\"\">The young people cycling through our justice system aren't abstractions to be managed or problems to be solved they are our children, carrying trauma we inflicted, responding to abandonment we created, reflecting back the violence we normalized. They are mirrors showing us exactly who we've chosen to become.</p><p id=\"\"><em id=\"\">Our mountains are both institutional and internal requiring courage, vulnerability, and an unwavering commitment to seeing beyond current limitations.</em></p><p id=\"\">The transformation Queensland needs, that Australia needs, that our world desperately needs, cannot be achieved through policy reform alone. It requires what Indigenous communities have always known, what our best organisational development work confirms: that healing the systems requires healing ourselves, that changing the world requires changing our consciousness, that sustainable transformation emerges from the inside out.</p><p id=\"\">This is the heart of A Curious Tractor's approach: recognising that the quality of our external systems reflects the quality of our internal capacity for connection, collaboration, and care. That the way we treat the most vulnerable in our society mirrors the way we treat the most vulnerable parts of ourselves.</p><p id=\"\"><em id=\"\">Money means fuck all if we don't have connections with people around us. Safety means nothing if it's built on other people's suffering. Being right is worthless if it comes at the cost of being human.</em></p><p id=\"\">The path forward requires us to become comfortable with not knowing, with being wrong, with having our assumptions challenged by people whose experiences we've never lived. It requires curiosity over certainty, questions over answers, vulnerability over defensiveness.</p><p id=\"\">What if we stopped trying to fix broken systems and started building new ones? What if we applied the same collaborative learning principles that transform organisations to transforming our approach to community safety? What if we measured success by how many young people we helped flourish rather than how many we managed to contain? What if we organised our communities around the principle that every person carries gifts the world desperately needs?</p><p id=\"\">This is not naive optimism - this is the same radical pragmatism that guides every A Curious Tractor engagement. The recognition that complex challenges require collective wisdom, that sustainable solutions emerge from authentic relationship, that transformation happens when we create conditions for it rather than trying to force it.</p><p id=\"\"><em id=\"\">The evidence is overwhelming that approaches rooted in healing, connection, and restoration create better outcomes for everyone involved.</em></p><p id=\"\">Portugal's health-focused drug policy. Norway's rehabilitation-centred prisons. Finland's collaborative education system. Boston's community policing model. These aren't utopian fantasies - they are practical demonstrations that different choices create different realities. They are large-scale applications of the same principles that make collaborative learning processes so transformative: starting with human dignity, honouring complexity, building from wisdom that already exists within communities.</p><p id=\"\">I'm here to think deeper about this. I'm going to say some real shit that people won't like. I'm here to push boundaries on what we accept as normal, as inevitable, as \"just the way things are.\"</p><p id=\"\">Because if we're not challenged to think differently, if we're not curious about whether we might be wrong, if we're not always questioning our assumptions about human nature and social possibilities, then we're just reproducing the same patterns that got us here.</p><p id=\"\"><em id=\"\">This blog, this work, A Curious Tractor itself, it's all an invitation to anyone ready to move beyond the binary thinking that keeps us trapped in cycles of harm.</em></p><p id=\"\">It's for people willing to examine their own investments in punishment and control. It's for communities ready to experiment with healing-centred responses to conflict. It's for organisations brave enough to design systems around human flourishing rather than fear and compliance. It's for anyone who suspects that the way things are is not the way things have to be.</p><p id=\"\"><em id=\"\">Together, we climb toward something that doesn't exist yet.</em></p><p id=\"\">Not because the path is clear, but because the destination is worthy. Not because we have all the answers, but because we're willing to live in the questions. Not because change is easy, but because the alternative - continuing to fund failure, to warehouse trauma, to systematically destroy the potential of our most vulnerable children is unacceptable.</p><h2 id=\"\">The Audacity of Love</h2><p id=\"\"><em id=\"\">Every breakthrough begins with the audacity to imagine differently.</em></p><p id=\"\">What I'm proposing through this work, through A Curious Tractor, through this writing, is not policy reform. What I'm proposing is a revolution in how we understand human nature, community safety, and our responsibility to each other. What I'm proposing is that we organise our society around the same radical assumptions that make collaborative learning so powerful: that every person carries wisdom, that collective intelligence emerges when we create conditions for it, that transformation is possible when we stop trying to force it and start creating space for it.</p><p id=\"\">This is the audacity of love: the willingness to see beyond current behaviour to human potential, to invest in possibilities rather than just manage problems, to build systems that call forth our highest rather than reinforce our lowest.</p><p id=\"\"><em id=\"\">In this moment of profound transition, we have a choice.</em></p><p id=\"\">We can continue pouring millions into the machinery of punishment while children sleep in police watch houses and Indigenous families are systematically destroyed. We can keep celebrating arrest statistics while ignoring the human cost of our collective failure to imagine better.</p><p id=\"\">Or we can choose the path that Portugal, Norway, and countless communities around the world have already mapped: the path from punishment to transformation, from fear to love, from systems that diminish to systems that dignify. The same path that guides every meaningful organisational transformation, every authentic leadership development process, every collaborative learning experience that actually changes how people see themselves and their possibilities.</p><p id=\"\"><em id=\"\">The choice is ours. The time is now. The future is unwritten.</em></p>",
+      "authorName": "Benjamin Knight",
+      "authorBio": null,
+      "articleType": "editorial",
+      "primaryProject": "act-main",
+      "relatedProjects": [
+        "act-main"
+      ],
+      "relatedProjectSlugs": [],
+      "publishedAt": "2026-01-09T23:40:59.476+00:00",
+      "createdAt": null,
+      "updatedAt": null,
+      "tags": [],
+      "themes": [],
+      "featuredImageUrl": null,
+      "featuredImageAlt": null,
+      "storyteller": {
+        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
+        "slug": "benjamin-knight",
+        "displayName": "Benjamin Knight",
+        "avatarUrl": null,
+        "bio": null
+      },
+      "media": {
+        "photoCount": 0,
+        "videoCount": 0,
+        "photoPreviews": [],
+        "videoPreviews": []
+      },
+      "ctas": [],
+      "visibility": "public",
+      "canonicalUrl": "https://empathyledger.com/articles/the-weight-of-silence-and-the-audacity-to-imagine-reflections-on-fear-hope-and-the-long-game-of-human-liberation",
+      "localPath": "/stories/the-weight-of-silence-and-the-audacity-to-imagine-reflections-on-fear-hope-and-the-long-game-of-human-liberation",
       "syndicationDestinations": [
         "act_el"
       ]
@@ -1497,7 +1127,7 @@
         "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
         "slug": "benjamin-knight",
         "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
+        "avatarUrl": null,
         "bio": null
       },
       "media": {
@@ -1535,100 +1165,8 @@
       },
       "ctas": [],
       "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/beyond-bars-joe-kwons-journey-to-reshape-society",
+      "canonicalUrl": "https://empathyledger.com/articles/beyond-bars-joe-kwons-journey-to-reshape-society",
       "localPath": "/stories/beyond-bars-joe-kwons-journey-to-reshape-society",
-      "syndicationDestinations": [
-        "act_el"
-      ]
-    },
-    {
-      "id": "5f62118a-763b-4694-9467-3edcb87b0fb6",
-      "title": "Building the ACT Ecosystem: A Vision for Community-Centered Technology",
-      "slug": "building-the-act-ecosystem-a-vision-for-community-centered-technology",
-      "subtitle": "How we are creating tools that put storytelling power in the hands of communities",
-      "excerpt": "<p>The ACT (A Curious Tractor) ecosystem represents a bold vision for technology that serves communities rather than extracting from them.</p>\n<h2>The Challenge</h2>\n<p>For too long, technology platfo...",
-      "content": "<p>The ACT (A Curious Tractor) ecosystem represents a bold vision for technology that serves communities rather than extracting from them.</p>\n<h2>The Challenge</h2>\n<p>For too long, technology platforms have been designed to extract value from communities - their data, their attention, their stories. We believe there is a better way.</p>\n<h2>Our Approach</h2>\n<p>Empathy Ledger sits at the heart of the ACT ecosystem, providing:</p>\n<ul>\n<li><strong>Story ownership</strong>: Communities maintain sovereignty over their narratives</li>\n<li><strong>Consent-first design</strong>: Every piece of data, every story shared, is governed by explicit consent</li>\n<li><strong>Three-tier visibility</strong>: Private, community, and public levels ensure appropriate sharing</li>\n</ul>\n<h2>What We Have Built</h2>\n<p>Across the ecosystem:</p>\n<ol>\n<li><strong>JusticeHub</strong> - Legal empowerment platform</li>\n<li><strong>ACT Farm</strong> - Agricultural and land management tools</li>\n<li><strong>Harvest</strong> - Resource sharing and distribution</li>\n<li><strong>Goods</strong> - Community marketplace</li>\n<li><strong>Placemat</strong> - Location-based community connection</li>\n<li><strong>Studio</strong> - Creative production tools</li>\n</ol>\n<p>Each project shares common infrastructure while maintaining its unique identity and purpose.</p>\n<h2>Looking Forward</h2>\n<p>We are just beginning. The editorial workflow you are reading this through is part of our commitment to democratizing content creation - allowing anyone in our community to share their voice.</p>\n",
-      "authorName": "Benjamin Knight",
-      "authorBio": null,
-      "articleType": "editorial",
-      "primaryProject": "empathy-ledger",
-      "relatedProjects": [
-        "justicehub",
-        "act-farm",
-        "harvest"
-      ],
-      "relatedProjectSlugs": [
-        "empathy-ledger",
-        "justicehub",
-        "act-farm",
-        "the-harvest",
-        "goods-on-country",
-        "black-cockatoo-valley"
-      ],
-      "publishedAt": "2026-01-08T04:05:50.612+00:00",
-      "createdAt": null,
-      "updatedAt": null,
-      "tags": [
-        "technology",
-        "community",
-        "storytelling",
-        "consent",
-        "ACT ecosystem"
-      ],
-      "themes": [],
-      "featuredImageUrl": null,
-      "featuredImageAlt": null,
-      "storyteller": {
-        "id": "8b5f3aa0-5955-43ac-8442-37e48e7fc810",
-        "slug": "benjamin-knight",
-        "displayName": "Benjamin Knight",
-        "avatarUrl": "https://empathyledger.com/api/media/ddcacf10-8ffa-4948-9cc0-5b33eb34594d/file",
-        "bio": null
-      },
-      "media": {
-        "photoCount": 0,
-        "videoCount": 0,
-        "photoPreviews": [],
-        "videoPreviews": []
-      },
-      "ctas": [
-        {
-          "id": "78694ea5-3fde-4e7e-a9c1-92ac56924582",
-          "position": "end",
-          "ctaType": "donate",
-          "buttonText": "Support Our Work",
-          "description": "Help us continue building community-centered technology",
-          "icon": "heart",
-          "style": "primary",
-          "urlTemplate": "https://act.place/donate?ref={article_id}",
-          "actionType": "link"
-        },
-        {
-          "id": "75be6c61-c4ec-4285-b14d-161b4cb4bc9f",
-          "position": "end",
-          "ctaType": "signup",
-          "buttonText": "Stay Connected",
-          "description": "Get updates on our latest stories and impact",
-          "icon": "mail",
-          "style": "secondary",
-          "urlTemplate": "https://act.place/newsletter?ref={article_id}",
-          "actionType": "modal"
-        },
-        {
-          "id": "36668829-f133-4bc3-a22e-937785968afd",
-          "position": "floating",
-          "ctaType": "share",
-          "buttonText": "Share This Story",
-          "description": "Help amplify this voice by sharing",
-          "icon": "share-2",
-          "style": "outline",
-          "urlTemplate": null,
-          "actionType": "share"
-        }
-      ],
-      "visibility": "public",
-      "canonicalUrl": "https://empathy-ledger-v2.vercel.app/articles/building-the-act-ecosystem-a-vision-for-community-centered-technology",
-      "localPath": "/stories/building-the-act-ecosystem-a-vision-for-community-centered-technology",
       "syndicationDestinations": [
         "act_el"
       ]

--- a/src/data/field-assignments.ts
+++ b/src/data/field-assignments.ts
@@ -46,14 +46,6 @@ export const FIELD_ASSIGNMENTS: Record<string, LivingFieldId[]> = {
   // this is the same work seen through the person leading it.
   "naidoc-with-jimmy": ["goods"],
 
-  // Richard Cassidy on Palm Island, the same partnership as "At the Speed of
-  // Ceremony". Nearer to mentorship than to the making work, but it is the same
-  // place and the same relationship.
-  "the-spirit-must-be-strong": ["goods"],
-
-  // Elders and youth on Kalkadoon Country. Reads partly as trip reflection, and
-  // the youth-and-Elders work is what the justice field is for.
-  "seeds-of-change-walking-with-elders-and-youth-on-kalkadoon-country": ["justice"],
 };
 
 /**
@@ -77,7 +69,6 @@ export const DELIBERATELY_UNASSIGNED: Record<string, string> = {
   "life-is-hard-but-its-not": "Personal reflection.",
   "the-weight-of-silence-and-the-audacity-to-imagine-reflections-on-fear-hope-and-the-long-game-of-human-liberation": "Series opener on fear and hope; thematic rather than field work.",
   "naidoc-with-jimmy": "Time with Jimmy Frank Jupurrurla; relationship piece.",
-  "between-waters-and-worlds-a-day-on-quandamooka-country": "Quandamooka Country day; knowledge-sharing rather than a field.",
   "conversation-camp": "Tagged black-cockatoo-valley upstream, which is land rather than a field of practice.",
   // "nhats-story-finding-belonging-and-purpose-at-the-hope-centre" and
   // "a-heros-journey-from-addiction-to-inspiration-the-life-of-vireak" sat here


### PR DESCRIPTION
## Summary
- consume Empathy Ledger editorial list/detail anonymously so integration credentials cannot promote non-public content into ACT static pages
- resync the governed editorial snapshot from the fixed production feed
- preserve local withdrawal tombstones and destination consent controls

## Verification
- Empathy Ledger production feed: 121 advertised media IDs / 242 full+thumbnail probes / 0 failures
- representative pending-consent media remains 403 for full and thumbnail and is absent from the feed
- database consent gate: 15/15 snapshot articles published, public, syndication-enabled, ACT-approved, unrevoked; required Elder approvals present
- ACT checker: 163 live / 0 dead across 21 rendered story pages
- ACT production build passes